### PR TITLE
feat: add failureReason() to VerificationResult and accountName to TOTP metadata

### DIFF
--- a/tokido-core-api/src/main/java/io/tokido/core/VerificationResult.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/VerificationResult.java
@@ -1,9 +1,23 @@
 package io.tokido.core;
 
+import java.util.Optional;
+
 /**
  * Marker interface for factor-specific verification results.
  * All implementations must report whether verification succeeded.
+ * <p>
+ * Factor-specific results may also expose a {@link #failureReason()} string
+ * (e.g. "invalid", "replay") to aid error handling by callers.
  */
 public interface VerificationResult {
     boolean valid();
+
+    /**
+     * Optional machine-readable failure reason.
+     * Present when {@link #valid()} is {@code false} and the factor provides one.
+     * Examples: {@code "invalid"}, {@code "replay"}, {@code "unconfirmed"}.
+     */
+    default Optional<String> failureReason() {
+        return Optional.empty();
+    }
 }

--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
@@ -183,5 +183,9 @@ public class MfaManager {
      * Simple verification result used internally for lifecycle rejections (e.g., unconfirmed).
      */
     record SimpleVerificationResult(boolean valid, String reason) implements VerificationResult {
+        @Override
+        public java.util.Optional<String> failureReason() {
+            return java.util.Optional.ofNullable(reason);
+        }
     }
 }

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -63,6 +63,7 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
         metadata.put("lastCounter", -1L);
         metadata.put("confirmed", false);
         metadata.put("createdAt", System.currentTimeMillis());
+        metadata.put("accountName", accountName);
 
         secretStore.store(userId, factorType(), secret, metadata);
 
@@ -120,6 +121,10 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
         Object lastUsedAt = stored.metadata().get("lastUsedAt");
         if (lastUsedAt != null) {
             attrs.put("lastUsedAt", lastUsedAt);
+        }
+        Object accountName = stored.metadata().get("accountName");
+        if (accountName != null) {
+            attrs.put("accountName", accountName);
         }
         return new FactorStatus(true, confirmed, Map.copyOf(attrs));
     }

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpVerificationResult.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpVerificationResult.java
@@ -9,4 +9,8 @@ import io.tokido.core.VerificationResult;
  * @param reason null on success; "invalid" for wrong code, "replay" for reused code
  */
 public record TotpVerificationResult(boolean valid, String reason) implements VerificationResult {
+    @Override
+    public java.util.Optional<String> failureReason() {
+        return java.util.Optional.ofNullable(reason);
+    }
 }


### PR DESCRIPTION
## Summary

- **`VerificationResult`**: add `default failureReason()` returning `Optional<String>` — callers can now inspect failure reasons without casting to concrete factor types
- **`TotpVerificationResult`** and **`MfaManager.SimpleVerificationResult`**: override `failureReason()` to expose their internal reason string
- **`TotpFactorProvider.enroll()`**: persist `accountName` in SecretStore metadata alongside `lastCounter`, `confirmed`, `createdAt`
- **`TotpFactorProvider.status()`**: include `accountName` in `FactorStatus` attributes when present

## Motivation

Required by tokido (the platform) to:
1. Read failure reasons from `VerificationResult` without pattern-matching on concrete types
2. Retrieve the TOTP account name from status without maintaining a separate storage field

## Test plan

- [ ] All existing tests pass (97 tests, 0 failures)
- [ ] No breaking changes to existing callers — `failureReason()` has a default impl, `accountName` in metadata is additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive API change: `VerificationResult` gains a default `failureReason()` and TOTP metadata now stores/returns `accountName`. Main risk is minor compatibility assumptions by callers around new metadata fields or newly-consumed failure reasons.
> 
> **Overview**
> Adds a new optional `VerificationResult.failureReason()` API so callers can read machine-readable failure causes without downcasting; `TotpVerificationResult` and the engine’s internal `SimpleVerificationResult` now surface their existing `reason` via this method.
> 
> TOTP enrollment now persists `accountName` into SecretStore metadata and `TotpFactorProvider.status()` includes it in returned attributes when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3867097671e924faf68fe780014e1624e344c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->