### PR TITLE
feat(totp): make confirmation step configurable

### DIFF
--- a/tokido-core-totp/pom.xml
+++ b/tokido-core-totp/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>tokido-core-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.tokido</groupId>
+            <artifactId>tokido-core-engine</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpConfig.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpConfig.java
@@ -12,6 +12,7 @@ public class TotpConfig {
     int windowSize = 1;
     String algorithm = "HmacSHA1";
     String issuer = "App";
+    boolean requiresConfirmation = true;
 
     public static TotpConfig defaults() {
         return new TotpConfig();
@@ -47,10 +48,21 @@ public class TotpConfig {
         return this;
     }
 
+    /**
+     * Whether TOTP enrollment follows the two-step confirm flow. Defaults to {@code true}.
+     * Set to {@code false} for trusted server-side provisioning where the factor should be
+     * immediately active without a separate {@code confirmEnrollment} step.
+     */
+    public TotpConfig requiresConfirmation(boolean requiresConfirmation) {
+        this.requiresConfirmation = requiresConfirmation;
+        return this;
+    }
+
     public int secretLength() { return secretLength; }
     public int codeLength() { return codeLength; }
     public int timeStepSeconds() { return timeStepSeconds; }
     public int windowSize() { return windowSize; }
     public String algorithm() { return algorithm; }
     public String issuer() { return issuer; }
+    public boolean requiresConfirmation() { return requiresConfirmation; }
 }

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -15,9 +15,11 @@ import java.util.Map;
  * Implements RFC 6238 with replay protection, configurable time window,
  * and GraalVM-safe QR code generation.
  *
- * <p>This provider requires confirmation: after {@code MfaManager.enroll()}, the user must
+ * <p>By default this provider requires confirmation: after {@code MfaManager.enroll()}, the user must
  * call {@code MfaManager.confirmEnrollment()} with a valid TOTP code before the factor
  * becomes active for verification.
+ * Use {@link TotpConfig#requiresConfirmation(boolean)} with {@code false} for server-side
+ * provisioning flows where the factor should be active immediately.
  *
  * <h2>Metadata written to SecretStore</h2>
  * <ul>
@@ -56,7 +58,7 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
 
     @Override
     public boolean requiresConfirmation() {
-        return true;
+        return config.requiresConfirmation();
     }
 
     @Override
@@ -133,7 +135,13 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
         if (stored == null) {
             return FactorStatus.notEnrolled();
         }
-        Boolean confirmed = (Boolean) stored.metadata().getOrDefault(SecretStore.Metadata.CONFIRMED, false);
+        boolean confirmed;
+        if (!requiresConfirmation()) {
+            confirmed = true;
+        } else {
+            Boolean c = (Boolean) stored.metadata().get(SecretStore.Metadata.CONFIRMED);
+            confirmed = c != null && c;
+        }
         Map<String, Object> attrs = new HashMap<>();
         attrs.put(SecretStore.Metadata.CREATED_AT, stored.metadata().get(SecretStore.Metadata.CREATED_AT));
         Object lastUsedAt = stored.metadata().get(SecretStore.Metadata.LAST_USED_AT);

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpConfigTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpConfigTest.java
@@ -3,6 +3,8 @@ package io.tokido.core.totp;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TotpConfigTest {
 
@@ -15,6 +17,7 @@ class TotpConfigTest {
         assertEquals(1, config.windowSize());
         assertEquals("HmacSHA1", config.algorithm());
         assertEquals("App", config.issuer());
+        assertTrue(config.requiresConfirmation());
     }
 
     @Test
@@ -33,5 +36,11 @@ class TotpConfigTest {
         assertEquals(2, config.windowSize());
         assertEquals("HmacSHA256", config.algorithm());
         assertEquals("MyApp", config.issuer());
+    }
+
+    @Test
+    void requiresConfirmationCanBeDisabled() {
+        TotpConfig config = TotpConfig.defaults().requiresConfirmation(false);
+        assertFalse(config.requiresConfirmation());
     }
 }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -29,6 +29,15 @@ class TotpFactorProviderTest {
     }
 
     @Test
+    void requiresConfirmationFollowsConfig() {
+        TotpFactorProvider strict = new TotpFactorProvider(TotpConfig.defaults(), store);
+        assertTrue(strict.requiresConfirmation());
+
+        TotpFactorProvider immediate = new TotpFactorProvider(TotpConfig.defaults().requiresConfirmation(false), store);
+        assertFalse(immediate.requiresConfirmation());
+    }
+
+    @Test
     void enrollGeneratesSecretAndQrCode() {
         TotpEnrollmentResult result = provider.enroll("user1", EnrollmentContext.empty());
 

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
@@ -1,0 +1,62 @@
+package io.tokido.core.totp;
+
+import io.tokido.core.EnrollmentContext;
+import io.tokido.core.FactorStatus;
+import io.tokido.core.StoredSecret;
+import io.tokido.core.VerificationResult;
+import io.tokido.core.engine.MfaManager;
+import io.tokido.core.spi.SecretStore;
+import io.tokido.core.test.InMemorySecretStore;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TotpMfaManagerIntegrationTest {
+
+    @Test
+    void totpWithoutConfirmationDoesNotWriteConfirmedMetadata() {
+        InMemorySecretStore store = new InMemorySecretStore();
+        TotpConfig config = TotpConfig.defaults().requiresConfirmation(false).issuer("App");
+        TotpFactorProvider totp = new TotpFactorProvider(config, store);
+        MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
+
+        mfa.enroll("u1", "totp", EnrollmentContext.empty());
+
+        StoredSecret stored = store.inspect("u1", "totp");
+        assertNotNull(stored);
+        assertNull(stored.metadata().get(SecretStore.Metadata.CONFIRMED));
+    }
+
+    @Test
+    void totpWithoutConfirmationVerifyWithoutConfirmEnrollment() {
+        InMemorySecretStore store = new InMemorySecretStore();
+        TotpConfig config = TotpConfig.defaults().requiresConfirmation(false).issuer("App");
+        TotpFactorProvider totp = new TotpFactorProvider(config, store);
+        MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
+
+        mfa.enroll("u1", "totp", EnrollmentContext.empty());
+
+        StoredSecret stored = store.inspect("u1", "totp");
+        byte[] secret = stored.secret();
+        long counter = System.currentTimeMillis() / 1000L / config.timeStepSeconds();
+        String codeStr = String.format("%06d", TotpAlgorithm.generate(secret, counter, config));
+
+        VerificationResult result = mfa.verify("u1", "totp", codeStr);
+        assertTrue(result.valid());
+    }
+
+    @Test
+    void totpWithoutConfirmationStatusIsConfirmed() {
+        InMemorySecretStore store = new InMemorySecretStore();
+        TotpConfig config = TotpConfig.defaults().requiresConfirmation(false).issuer("App");
+        TotpFactorProvider totp = new TotpFactorProvider(config, store);
+        MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
+
+        mfa.enroll("u1", "totp", EnrollmentContext.empty());
+
+        FactorStatus st = mfa.status("u1", "totp");
+        assertTrue(st.enrolled());
+        assertTrue(st.confirmed());
+    }
+}
+


### PR DESCRIPTION
## What
Add `TotpConfig.requiresConfirmation(boolean)` (default `true`) so TOTP enrollment can be made immediately active for trusted server-side provisioning flows.

Closes #2

## Why
`TotpFactorProvider.requiresConfirmation()` was effectively hardcoded, forcing the engine to write `confirmed=false` and requiring a separate confirm step even when the application considers enrollment immediately active.

## Testing
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)