### PR TITLE
docs(spi): document VerificationContext usage

### DIFF
--- a/tokido-core-api/src/main/java/io/tokido/core/VerificationContext.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/VerificationContext.java
@@ -1,9 +1,20 @@
 package io.tokido.core;
 
+import io.tokido.core.spi.FactorProvider;
+
 import java.util.Map;
 
 /**
- * Context passed to factor verification, carrying factor-specific properties.
+ * Context passed to factor verification, carrying factor-specific properties for the
+ * {@link FactorProvider#verify(String, String, VerificationContext)} SPI.
+ * <p>
+ * <strong>Built-in providers:</strong> the built-in Tokido factor providers do not read
+ * {@code properties}; all verification inputs come from the credential string and persisted
+ * secrets. Pass {@link #empty()} unless you are using a custom {@link FactorProvider} that
+ * documents supported keys.
+ * <p>
+ * This type exists so custom factors can accept structured verification-time inputs in a
+ * forward-compatible way without changing the SPI signature.
  *
  * @param properties factor-specific key-value pairs
  */

--- a/tokido-core-api/src/main/java/io/tokido/core/spi/FactorProvider.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/spi/FactorProvider.java
@@ -41,6 +41,10 @@ public interface FactorProvider<E extends EnrollmentResult, V extends Verificati
 
     /**
      * Verify a credential for this factor.
+     * <p>
+     * The {@link VerificationContext} carries provider-specific properties. Built-in Tokido
+     * providers ignore {@link VerificationContext#properties()}; custom implementations should
+     * document which keys they read and their types.
      */
     V verify(String userId, String credential, VerificationContext ctx);
 


### PR DESCRIPTION
## What
Document the intended use of `VerificationContext` and clarify that built-in providers currently ignore its properties.

Closes #5

## Why
The API surface suggests contextual verification is supported, but without documentation callers cannot use it meaningfully.

## Testing
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)