### PR TITLE
ci(release): fail if sources/javadocs are missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Build and verify
         run: mvn verify
 
+      - name: Verify source and Javadoc artifacts
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          for m in tokido-core-api tokido-core-test tokido-core-engine tokido-core-totp tokido-core-recovery; do
+            test -f "$m/target/${m}-${VERSION}-sources.jar"
+            test -f "$m/target/${m}-${VERSION}-javadoc.jar"
+          done
+
       - name: Publish to Maven Central
         run: mvn deploy -P release -DskipTests
         env:


### PR DESCRIPTION
## What
Add a release workflow check that verifies every module produced both `*-sources.jar` and `*-javadoc.jar` for the release version before deploying to Maven Central.

Closes #3

## Why
Consumers rely on `mvn dependency:sources` / IDE source downloads. A release should fail fast if sources/javadocs are not attached.

## Testing
- [x] `mvn -DskipTests verify`

Made with [Cursor](https://cursor.com)