### PR TITLE
fix(engine): delegate status() to factor provider

### DIFF
--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
@@ -212,14 +212,7 @@ public class MfaManager {
      * @throws FactorNotRegisteredException if the factor type is not registered
      */
     public FactorStatus status(String userId, String factorType) {
-        requireFactor(factorType);
-
-        StoredSecret stored = secretStore.load(userId, factorType);
-        if (stored == null) {
-            return FactorStatus.notEnrolled();
-        }
-
-        FactorProvider<?, ?> provider = factors.get(factorType);
+        FactorProvider<?, ?> provider = requireFactor(factorType);
         return provider.status(userId);
     }
 


### PR DESCRIPTION
## What
Make `MfaManager.status(userId, factorType)` delegate directly to the registered `FactorProvider.status(userId)`.

Closes #6

## Why
The factor provider already owns the interpretation of stored state. Delegating avoids duplicate `SecretStore.load()` calls and keeps status semantics factor-specific.

## Testing
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)