### PR TITLE
feat(totp): add typed TotpEnrollmentContext

### DIFF
--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContext.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContext.java
@@ -1,0 +1,24 @@
+package io.tokido.core.totp;
+
+import io.tokido.core.EnrollmentContext;
+import io.tokido.core.spi.SecretStore;
+
+import java.util.Objects;
+
+/**
+ * Type-safe enrollment input for {@link TotpFactorProvider}.
+ * <p>
+ * Prefer this over raw {@link EnrollmentContext#of(String, Object)} so the account name for the
+ * otpauth URI is required at compile time and cannot be mistyped or omitted.
+ */
+public record TotpEnrollmentContext(String accountName) {
+
+    public TotpEnrollmentContext {
+        Objects.requireNonNull(accountName, "accountName");
+    }
+
+    public EnrollmentContext asEnrollmentContext() {
+        return EnrollmentContext.of(SecretStore.Metadata.ACCOUNT_NAME, accountName);
+    }
+}
+

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -67,7 +67,7 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
         new SecureRandom().nextBytes(secret);
 
         String base32Secret = Base32.encode(secret);
-        String accountName = (String) ctx.properties().getOrDefault("accountName", userId);
+        String accountName = resolveAccountName(userId, ctx);
         String secretUri = "otpauth://totp/" + urlEncode(accountName)
                 + "?secret=" + base32Secret
                 + "&issuer=" + urlEncode(config.issuer());
@@ -153,6 +153,19 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
             attrs.put(SecretStore.Metadata.ACCOUNT_NAME, accountName);
         }
         return new FactorStatus(true, confirmed, Map.copyOf(attrs));
+    }
+
+    private static String resolveAccountName(String userId, EnrollmentContext ctx) {
+        Object v = ctx.properties().get(SecretStore.Metadata.ACCOUNT_NAME);
+        if (v instanceof String s) {
+            return s;
+        }
+        // Backward compatibility with the pre-Metadata constant usage.
+        Object legacy = ctx.properties().get("accountName");
+        if (legacy instanceof String s) {
+            return s;
+        }
+        return userId;
     }
 
     private static String urlEncode(String value) {

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -69,6 +69,14 @@ class TotpFactorProviderTest {
     }
 
     @Test
+    void enrollUsesTotpEnrollmentContext() {
+        TotpEnrollmentResult result = provider.enroll("user1",
+                new TotpEnrollmentContext("alice@example.com").asEnrollmentContext());
+
+        assertTrue(result.secretUri().contains("alice%40example.com"));
+    }
+
+    @Test
     void verifyAcceptsCurrentCode() {
         provider.enroll("user1", EnrollmentContext.empty());
 

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
@@ -20,7 +20,7 @@ class TotpMfaManagerIntegrationTest {
         TotpFactorProvider totp = new TotpFactorProvider(config, store);
         MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
 
-        mfa.enroll("u1", "totp", EnrollmentContext.empty());
+        mfa.enroll("u1", "totp", new TotpEnrollmentContext("alice@example.com").asEnrollmentContext());
 
         StoredSecret stored = store.inspect("u1", "totp");
         assertNotNull(stored);


### PR DESCRIPTION
## What
Introduce `TotpEnrollmentContext` as a typed alternative to `EnrollmentContext(Map)` for TOTP enrollment.

Closes #4

## Why
Using untyped map keys for enrollment inputs makes it easy to omit or mistype the only meaningful input for TOTP enrollment (`accountName`).

## Testing
- [x] `mvn verify`

Note: Replaces PR #8 (closed when the stacked base branch was deleted during merge of PR #7).

Made with [Cursor](https://cursor.com)