### PR TITLE
ci: upgrade GitHub actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-reports
           path: '**/target/site/jacoco/'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## What
Upgrade GitHub Actions used in CI/release workflows to versions that run on Node.js 24.

## Why
GitHub is deprecating Node.js 20-based JavaScript actions on runners; upgrading eliminates the deprecation notices and keeps workflows future-proof.

## Changes
- `actions/checkout@v4` -> `actions/checkout@v5`
- `actions/setup-java@v4` -> `actions/setup-java@v5`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v6`

## Testing
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)