### PR TITLE
ci: harden GHA permissions and pin actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,17 @@ on:
 
 permissions:
   contents: read
+  # setup-java `cache: maven` uses actions/cache, which needs Actions cache API access
+  actions: write
 
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -27,7 +29,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-reports
           path: '**/target/site/jacoco/'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,18 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
+  # setup-java `cache: maven` uses actions/cache, which needs Actions cache API access
+  actions: write
 
 jobs:
   release:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -31,7 +33,7 @@ jobs:
           mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false -q
 
       - name: Build and verify
-        run: mvn verify
+        run: mvn verify -P release
 
       - name: Verify source and Javadoc artifacts
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>5.11.4</junit.version>
-        <jacoco.version>0.8.12</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <surefire.version>3.5.4</surefire.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
     </properties>
@@ -145,16 +145,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.11.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals><goal>jar</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -163,6 +153,16 @@
             <id>release</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.11.2</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals><goal>jar</goal></goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Pin `actions/checkout`, `actions/setup-java`, and `actions/upload-artifact` to immutable commit SHAs (comments note the tag).
- Reduce `GITHUB_TOKEN` permissions: `contents: read` everywhere; add `actions: write` only where required for `setup-java` Maven dependency caching (`actions/cache`).
- Release workflow no longer uses `contents: write` (Maven Central publish uses `OSSRH_*` / GPG secrets, not repo contents API).
- Align Maven with workflows: attach Javadoc JARs only under the `release` profile and run `mvn verify -P release` before artifact checks; bump JaCoCo to **0.8.14** for modern JDK bytecode.

Closes #20

Made with [Cursor](https://cursor.com)