### PR TITLE
fix(totp): surface QR generation failures on enrollment

### DIFF
--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentResult.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentResult.java
@@ -6,7 +6,7 @@ import io.tokido.core.EnrollmentResult;
  * Result of TOTP enrollment, containing the data the user needs to set up their authenticator.
  *
  * @param secretUri    otpauth:// URI for authenticator apps
- * @param qrCodeBase64 PNG image of the QR code, base64-encoded
+ * @param qrCodeBase64 PNG image of the QR code, base64-encoded (non-empty when enrollment succeeds)
  */
 public record TotpEnrollmentResult(String secretUri, String qrCodeBase64) implements EnrollmentResult {
 }

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -9,6 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * TOTP (Time-based One-Time Password) factor provider.
@@ -36,19 +38,31 @@ import java.util.Map;
  * engine ({@code MfaManager}) and is never set by this provider.
  *
  * <p>Runtime dependency: {@code com.google.zxing:core} (lazily loaded on first enrollment).
+ *
+ * <p>Enrollment order: the otpauth URI is built, a QR PNG is generated, then the secret is stored.
+ * If QR generation fails, {@link TotpQrCodeGenerationException} is thrown and nothing is persisted.
  */
 public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, TotpVerificationResult> {
 
     private final TotpConfig config;
     private final SecretStore secretStore;
+    private final Function<String, String> qrToPngBase64;
 
     public TotpFactorProvider(TotpConfig config, SecretStore secretStore) {
-        this.config = config;
-        this.secretStore = secretStore;
+        this(config, secretStore, QrCodeGenerator::toPngBase64);
     }
 
     public TotpFactorProvider(SecretStore secretStore) {
         this(TotpConfig.defaults(), secretStore);
+    }
+
+    /**
+     * Package-private for tests: supply a function that maps otpauth URIs to base64 PNG data.
+     */
+    TotpFactorProvider(TotpConfig config, SecretStore secretStore, Function<String, String> qrToPngBase64) {
+        this.config = config;
+        this.secretStore = secretStore;
+        this.qrToPngBase64 = Objects.requireNonNull(qrToPngBase64, "qrToPngBase64");
     }
 
     @Override
@@ -74,9 +88,11 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
 
         String qrCodeBase64;
         try {
-            qrCodeBase64 = QrCodeGenerator.toPngBase64(secretUri);
+            qrCodeBase64 = qrToPngBase64.apply(secretUri);
+        } catch (TotpQrCodeGenerationException e) {
+            throw e;
         } catch (RuntimeException e) {
-            qrCodeBase64 = "";
+            throw new TotpQrCodeGenerationException(secretUri, e);
         }
 
         Map<String, Object> metadata = new HashMap<>();

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpQrCodeGenerationException.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpQrCodeGenerationException.java
@@ -1,0 +1,21 @@
+package io.tokido.core.totp;
+
+/**
+ * Thrown when QR code generation fails during TOTP enrollment.
+ *
+ * <p>Enrollment is aborted before the secret is written to {@link io.tokido.core.spi.SecretStore},
+ * so the user remains unenrolled for this factor and {@link #secretUri()} refers only to the URI
+ * that QR encoding attempted (for logging or diagnostics).
+ */
+public final class TotpQrCodeGenerationException extends RuntimeException {
+    private final String secretUri;
+
+    public TotpQrCodeGenerationException(String secretUri, Throwable cause) {
+        super("Failed to generate QR code for TOTP enrollment", cause);
+        this.secretUri = secretUri;
+    }
+
+    public String secretUri() {
+        return secretUri;
+    }
+}

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -50,6 +50,24 @@ class TotpFactorProviderTest {
     }
 
     @Test
+    void enrollThrowsWhenQrGenerationFailsAndDoesNotStoreSecret() {
+        TotpFactorProvider failing = new TotpFactorProvider(
+                TotpConfig.defaults().issuer("TestApp"),
+                store,
+                uri -> {
+                    throw new RuntimeException("simulated QR failure");
+                });
+
+        TotpQrCodeGenerationException ex = assertThrows(TotpQrCodeGenerationException.class,
+                () -> failing.enroll("user1", EnrollmentContext.empty()));
+
+        assertNotNull(ex.secretUri());
+        assertTrue(ex.secretUri().startsWith("otpauth://totp/"));
+        assertEquals("simulated QR failure", ex.getCause().getMessage());
+        assertFalse(store.hasSecret("user1", "totp"));
+    }
+
+    @Test
     void enrollStoresSecret() {
         provider.enroll("user1", EnrollmentContext.empty());
 


### PR DESCRIPTION
## Summary
- Throw `TotpQrCodeGenerationException` when QR PNG encoding fails instead of returning an empty `qrCodeBase64`.
- Build otpauth URI → encode QR → then `SecretStore.store` so a QR failure leaves no persisted enrollment.
- Add package-private `TotpFactorProvider` constructor with `Function<String,String>` for injecting a failing encoder in tests.

Closes #19

Made with [Cursor](https://cursor.com)