### PR TITLE
fix: confirmEnrollment does not advance TOTP replay state

### DIFF
--- a/tokido-core-api/src/main/java/io/tokido/core/VerificationContext.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/VerificationContext.java
@@ -8,10 +8,11 @@ import java.util.Map;
  * Context passed to factor verification, carrying factor-specific properties for the
  * {@link FactorProvider#verify(String, String, VerificationContext)} SPI.
  * <p>
- * <strong>Built-in providers:</strong> the built-in Tokido factor providers do not read
- * {@code properties}; all verification inputs come from the credential string and persisted
- * secrets. Pass {@link #empty()} unless you are using a custom {@link FactorProvider} that
- * documents supported keys.
+ * <strong>Built-in providers:</strong> the TOTP factor reads
+ * {@link #SKIP_VERIFICATION_PROGRESS_PERSISTENCE} when set by the engine for
+ * {@code MfaManager.confirmEnrollment}. Other built-in factors ignore {@code properties};
+ * pass {@link #empty()} unless you are using a custom {@link FactorProvider} that documents
+ * supported keys.
  * <p>
  * This type exists so custom factors can accept structured verification-time inputs in a
  * forward-compatible way without changing the SPI signature.
@@ -20,7 +21,32 @@ import java.util.Map;
  */
 public record VerificationContext(Map<String, Object> properties) {
 
+    /**
+     * Property key. When {@link Boolean#TRUE}, successful verification must validate the
+     * credential but must not persist replay / usage progress (e.g. TOTP {@code lastCounter}).
+     * The MFA engine sets this for {@code MfaManager.confirmEnrollment}; {@code MfaManager.verify}
+     * always uses a context where this flag is absent or false.
+     */
+    public static final String SKIP_VERIFICATION_PROGRESS_PERSISTENCE =
+            "io.tokido.skipVerificationProgressPersistence";
+
     public static VerificationContext empty() {
         return new VerificationContext(Map.of());
+    }
+
+    /**
+     * Context used by {@code MfaManager.confirmEnrollment} so factors can validate a credential
+     * without advancing replay state that must apply only after enrollment is confirmed.
+     */
+    public static VerificationContext enrollmentConfirmation() {
+        return new VerificationContext(Map.of(SKIP_VERIFICATION_PROGRESS_PERSISTENCE, Boolean.TRUE));
+    }
+
+    /**
+     * Whether successful verification should persist factor progress (replay counters, etc.).
+     * Returns false only when {@link #SKIP_VERIFICATION_PROGRESS_PERSISTENCE} is {@code true}.
+     */
+    public static boolean shouldPersistVerificationProgress(VerificationContext ctx) {
+        return !Boolean.TRUE.equals(ctx.properties().get(SKIP_VERIFICATION_PROGRESS_PERSISTENCE));
     }
 }

--- a/tokido-core-api/src/main/java/io/tokido/core/spi/FactorProvider.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/spi/FactorProvider.java
@@ -42,9 +42,11 @@ public interface FactorProvider<E extends EnrollmentResult, V extends Verificati
     /**
      * Verify a credential for this factor.
      * <p>
-     * The {@link VerificationContext} carries provider-specific properties. Built-in Tokido
-     * providers ignore {@link VerificationContext#properties()}; custom implementations should
-     * document which keys they read and their types.
+     * The {@link VerificationContext} carries provider-specific properties. The MFA engine passes
+     * {@link VerificationContext#enrollmentConfirmation()} for enrollment confirmation; factors
+     * that persist replay or consumption state must not update that state when that context is
+     * used. Other built-in providers ignore {@link VerificationContext#properties()};
+     * custom implementations should document which keys they read and their types.
      */
     V verify(String userId, String credential, VerificationContext ctx);
 

--- a/tokido-core-api/src/main/java/io/tokido/core/spi/SecretStore.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/spi/SecretStore.java
@@ -31,7 +31,8 @@ import java.util.Map;
  * <h3>MfaManager.confirmEnrollment(userId, factorType, credential)</h3>
  * <ol>
  *   <li>{@link #load(String, String)} — reads current state including {@code confirmed} flag</li>
- *   <li>Factor provider verifies the credential internally (no store calls)</li>
+ *   <li>Factor provider verifies the credential internally without persisting verification progress
+ *       (e.g. TOTP does not write {@code lastCounter} / {@code lastUsedAt} during this step)</li>
  *   <li>On success: {@link #update(String, String, Map)} with {@code {confirmed: true}}</li>
  *   <li>On failure: no store calls</li>
  * </ol>

--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
@@ -108,7 +108,8 @@ public class MfaManager {
      * <p>SecretStore calls made during this operation:
      * <ol>
      *   <li>{@code load()} — reads current state including {@code confirmed} flag</li>
-     *   <li>Provider verifies credential internally (no store calls)</li>
+     *   <li>Provider verifies credential internally without persisting verification progress
+     *       (e.g. TOTP does not advance {@code lastCounter} / {@code lastUsedAt} here)</li>
      *   <li>On success: {@code update({confirmed: true})}</li>
      * </ol>
      *
@@ -133,7 +134,7 @@ public class MfaManager {
                     .formatted(userId, factorType));
         }
 
-        VerificationResult result = provider.verify(userId, credential, VerificationContext.empty());
+        VerificationResult result = provider.verify(userId, credential, VerificationContext.enrollmentConfirmation());
         if (result.valid()) {
             secretStore.update(userId, factorType, Map.of(SecretStore.Metadata.CONFIRMED, true));
             audit(userId, factorType, "confirmed");

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -24,7 +24,9 @@ import java.util.Map;
  * <h2>Metadata written to SecretStore</h2>
  * <ul>
  *   <li>{@link SecretStore.Metadata#LAST_COUNTER} — set to {@code -1L} on enrollment;
- *       updated to the accepted counter on each successful verification</li>
+ *       updated to the accepted counter on each successful {@code MfaManager#verify} (not when
+ *       validating during {@code MfaManager#confirmEnrollment}, which checks the code without
+ *       advancing replay state)</li>
  *   <li>{@link SecretStore.Metadata#CREATED_AT} — epoch-millisecond timestamp of enrollment</li>
  *   <li>{@link SecretStore.Metadata#ACCOUNT_NAME} — account name used in the otpauth URI;
  *       defaults to userId if not provided in the enrollment context</li>
@@ -114,10 +116,12 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
                 if (c <= lastCounter) {
                     return new TotpVerificationResult(false, "replay");
                 }
-                secretStore.update(userId, factorType(), Map.of(
-                        SecretStore.Metadata.LAST_COUNTER, c,
-                        SecretStore.Metadata.LAST_USED_AT, System.currentTimeMillis()
-                ));
+                if (VerificationContext.shouldPersistVerificationProgress(ctx)) {
+                    secretStore.update(userId, factorType(), Map.of(
+                            SecretStore.Metadata.LAST_COUNTER, c,
+                            SecretStore.Metadata.LAST_USED_AT, System.currentTimeMillis()
+                    ));
+                }
                 return new TotpVerificationResult(true, null);
             }
         }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -1,6 +1,7 @@
 package io.tokido.core.totp;
 
 import io.tokido.core.*;
+import io.tokido.core.spi.SecretStore;
 import io.tokido.core.test.InMemorySecretStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -207,5 +208,30 @@ class TotpFactorProviderTest {
 
         TotpVerificationResult result = provider.verify("user1", codeStr, VerificationContext.empty());
         assertTrue(result.valid());
+    }
+
+    @Test
+    void verifyWithEnrollmentConfirmationContextDoesNotPersistReplayState() {
+        provider.enroll("user1", EnrollmentContext.empty());
+
+        StoredSecret stored = store.inspect("user1", "totp");
+        byte[] secret = stored.secret();
+        long counter = System.currentTimeMillis() / 1000L / 30L;
+        int code = TotpAlgorithm.generate(secret, counter, TotpConfig.defaults());
+        String codeStr = String.format("%06d", code);
+
+        TotpVerificationResult confirm = provider.verify("user1", codeStr, VerificationContext.enrollmentConfirmation());
+        assertTrue(confirm.valid());
+
+        StoredSecret afterConfirm = store.inspect("user1", "totp");
+        assertEquals(-1L, ((Number) afterConfirm.metadata().get(SecretStore.Metadata.LAST_COUNTER)).longValue());
+        assertNull(afterConfirm.metadata().get(SecretStore.Metadata.LAST_USED_AT));
+
+        TotpVerificationResult firstVerify = provider.verify("user1", codeStr, VerificationContext.empty());
+        assertTrue(firstVerify.valid());
+
+        TotpVerificationResult replay = provider.verify("user1", codeStr, VerificationContext.empty());
+        assertFalse(replay.valid());
+        assertEquals("replay", replay.reason());
     }
 }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
@@ -58,5 +58,34 @@ class TotpMfaManagerIntegrationTest {
         assertTrue(st.enrolled());
         assertTrue(st.confirmed());
     }
+
+    @Test
+    void confirmEnrollmentDoesNotAdvanceTotpReplayStateSoVerifyAcceptsSameCode() {
+        InMemorySecretStore store = new InMemorySecretStore();
+        TotpConfig config = TotpConfig.defaults().issuer("App");
+        TotpFactorProvider totp = new TotpFactorProvider(config, store);
+        MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
+
+        mfa.enroll("u1", "totp", EnrollmentContext.empty());
+
+        StoredSecret enrolled = store.inspect("u1", "totp");
+        byte[] secret = enrolled.secret();
+        long counter = System.currentTimeMillis() / 1000L / config.timeStepSeconds();
+        String code = String.format("%06d", TotpAlgorithm.generate(secret, counter, config));
+
+        VerificationResult confirmResult = mfa.confirmEnrollment("u1", "totp", code);
+        assertTrue(confirmResult.valid());
+
+        StoredSecret afterConfirm = store.inspect("u1", "totp");
+        assertEquals(-1L, ((Number) afterConfirm.metadata().get(SecretStore.Metadata.LAST_COUNTER)).longValue());
+        assertNull(afterConfirm.metadata().get(SecretStore.Metadata.LAST_USED_AT));
+
+        VerificationResult verifyResult = mfa.verify("u1", "totp", code);
+        assertTrue(verifyResult.valid());
+
+        VerificationResult replayResult = mfa.verify("u1", "totp", code);
+        assertFalse(replayResult.valid());
+        assertEquals("replay", replayResult.failureReason().orElse(null));
+    }
 }
 


### PR DESCRIPTION
## Summary
Closes #16.

`MfaManager.confirmEnrollment` now calls `FactorProvider.verify` with `VerificationContext.enrollmentConfirmation()`. `TotpFactorProvider` skips persisting `lastCounter` / `lastUsedAt` when that context is used, so the same code remains valid for the first real `verify` after confirmation.

## Verification
- `mvn verify -Djacoco.skip=true -Dmaven.javadoc.skip=true` (local JDK 25; CI runs `mvn verify` on Java 21)

Made with [Cursor](https://cursor.com)