### PR TITLE
fix(totp): omit accountName from FactorStatus attributes

### DIFF
--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -27,7 +27,8 @@ import java.util.Map;
  *       updated to the accepted counter on each successful verification</li>
  *   <li>{@link SecretStore.Metadata#CREATED_AT} — epoch-millisecond timestamp of enrollment</li>
  *   <li>{@link SecretStore.Metadata#ACCOUNT_NAME} — account name used in the otpauth URI;
- *       defaults to userId if not provided in the enrollment context</li>
+ *       defaults to userId if not provided in the enrollment context. This value is not included
+ *       in {@link #status(String)} attributes (it is often PII such as an email address).</li>
  *   <li>{@link SecretStore.Metadata#LAST_USED_AT} — epoch-millisecond timestamp of the most
  *       recent successful verification; absent until first use</li>
  * </ul>
@@ -147,10 +148,6 @@ public class TotpFactorProvider implements FactorProvider<TotpEnrollmentResult, 
         Object lastUsedAt = stored.metadata().get(SecretStore.Metadata.LAST_USED_AT);
         if (lastUsedAt != null) {
             attrs.put(SecretStore.Metadata.LAST_USED_AT, lastUsedAt);
-        }
-        Object accountName = stored.metadata().get(SecretStore.Metadata.ACCOUNT_NAME);
-        if (accountName != null) {
-            attrs.put(SecretStore.Metadata.ACCOUNT_NAME, accountName);
         }
         return new FactorStatus(true, confirmed, Map.copyOf(attrs));
     }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -1,6 +1,7 @@
 package io.tokido.core.totp;
 
 import io.tokido.core.*;
+import io.tokido.core.spi.SecretStore;
 import io.tokido.core.test.InMemorySecretStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -149,6 +150,17 @@ class TotpFactorProviderTest {
         assertTrue(status.enrolled());
         assertFalse(status.confirmed()); // not yet confirmed
         assertNotNull(status.attributes().get("createdAt"));
+    }
+
+    @Test
+    void statusDoesNotExposeAccountName() {
+        provider.enroll("user1",
+                EnrollmentContext.of(SecretStore.Metadata.ACCOUNT_NAME, "alice@example.com"));
+        StoredSecret stored = store.inspect("user1", "totp");
+        assertEquals("alice@example.com", stored.metadata().get(SecretStore.Metadata.ACCOUNT_NAME));
+
+        FactorStatus status = provider.status("user1");
+        assertFalse(status.attributes().containsKey(SecretStore.Metadata.ACCOUNT_NAME));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `TotpFactorProvider.status()` no longer puts `SecretStore.Metadata.ACCOUNT_NAME` in `FactorStatus.attributes` (account name is often PII, e.g. email).
- The value remains stored in SecretStore metadata for otpauth URIs and server-side use.
- Added `statusDoesNotExposeAccountName` test.

Closes #17

Made with [Cursor](https://cursor.com)