### PR TITLE
fix(totp): default to no confirmation required

### DIFF
--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpConfig.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpConfig.java
@@ -12,7 +12,7 @@ public class TotpConfig {
     int windowSize = 1;
     String algorithm = "HmacSHA1";
     String issuer = "App";
-    boolean requiresConfirmation = true;
+    boolean requiresConfirmation = false;
 
     public static TotpConfig defaults() {
         return new TotpConfig();
@@ -49,9 +49,9 @@ public class TotpConfig {
     }
 
     /**
-     * Whether TOTP enrollment follows the two-step confirm flow. Defaults to {@code true}.
-     * Set to {@code false} for trusted server-side provisioning where the factor should be
-     * immediately active without a separate {@code confirmEnrollment} step.
+     * Whether TOTP enrollment follows the two-step confirm flow. Defaults to {@code false}.
+     * Set to {@code true} for flows where enrollment should remain pending until
+     * {@code confirmEnrollment} succeeds.
      */
     public TotpConfig requiresConfirmation(boolean requiresConfirmation) {
         this.requiresConfirmation = requiresConfirmation;

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpFactorProvider.java
@@ -17,11 +17,10 @@ import java.util.function.Function;
  * Implements RFC 6238 with replay protection, configurable time window,
  * and GraalVM-safe QR code generation.
  *
- * <p>By default this provider requires confirmation: after {@code MfaManager.enroll()}, the user must
- * call {@code MfaManager.confirmEnrollment()} with a valid TOTP code before the factor
- * becomes active for verification.
- * Use {@link TotpConfig#requiresConfirmation(boolean)} with {@code false} for server-side
- * provisioning flows where the factor should be active immediately.
+ * <p>By default this provider does not require confirmation and is active immediately after
+ * {@code MfaManager.enroll()}.
+ * Set {@link TotpConfig#requiresConfirmation(boolean)} to {@code true} for flows where the
+ * user must call {@code MfaManager.confirmEnrollment()} before verification is accepted.
  *
  * <h2>Metadata written to SecretStore</h2>
  * <ul>

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpConfigTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpConfigTest.java
@@ -17,7 +17,7 @@ class TotpConfigTest {
         assertEquals(1, config.windowSize());
         assertEquals("HmacSHA1", config.algorithm());
         assertEquals("App", config.issuer());
-        assertTrue(config.requiresConfirmation());
+        assertFalse(config.requiresConfirmation());
     }
 
     @Test

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -29,16 +29,16 @@ class TotpFactorProviderTest {
 
     @Test
     void requiresConfirmation() {
-        assertTrue(provider.requiresConfirmation());
+        assertFalse(provider.requiresConfirmation());
     }
 
     @Test
     void requiresConfirmationFollowsConfig() {
         TotpFactorProvider strict = new TotpFactorProvider(TotpConfig.defaults(), store);
-        assertTrue(strict.requiresConfirmation());
+        assertFalse(strict.requiresConfirmation());
 
-        TotpFactorProvider immediate = new TotpFactorProvider(TotpConfig.defaults().requiresConfirmation(false), store);
-        assertFalse(immediate.requiresConfirmation());
+        TotpFactorProvider confirm = new TotpFactorProvider(TotpConfig.defaults().requiresConfirmation(true), store);
+        assertTrue(confirm.requiresConfirmation());
     }
 
     @Test
@@ -188,7 +188,7 @@ class TotpFactorProviderTest {
         provider.enroll("user1", EnrollmentContext.empty());
         FactorStatus status = provider.status("user1");
         assertTrue(status.enrolled());
-        assertFalse(status.confirmed()); // not yet confirmed
+        assertTrue(status.confirmed()); // confirmation is disabled by default
         assertNotNull(status.attributes().get("createdAt"));
     }
 

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
@@ -62,7 +62,7 @@ class TotpMfaManagerIntegrationTest {
     @Test
     void confirmEnrollmentDoesNotAdvanceTotpReplayStateSoVerifyAcceptsSameCode() {
         InMemorySecretStore store = new InMemorySecretStore();
-        TotpConfig config = TotpConfig.defaults().issuer("App");
+        TotpConfig config = TotpConfig.defaults().requiresConfirmation(true).issuer("App");
         TotpFactorProvider totp = new TotpFactorProvider(config, store);
         MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
 


### PR DESCRIPTION
## Summary
Default `TotpConfig.requiresConfirmation` to `false` to avoid leaving direct API enrollments in a silent pending state.

Closes #23

## Verification
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)