### PR TITLE
docs(api): document FactorStatus attributes for built-in factors

### DIFF
--- a/tokido-core-api/src/main/java/io/tokido/core/FactorStatus.java
+++ b/tokido-core-api/src/main/java/io/tokido/core/FactorStatus.java
@@ -7,7 +7,25 @@ import java.util.Map;
  *
  * @param enrolled   whether the user has an enrollment record
  * @param confirmed  whether the enrollment has been confirmed (always true for factors that don't require confirmation)
- * @param attributes factor-specific attributes (e.g., backup codes remaining, last used timestamp)
+ * @param attributes factor-specific attributes. Keys and value types are defined by each factor provider.
+ *
+ *                   <h2>Built-in factor attribute keys</h2>
+ *                   <p>The built-in providers use the following keys:
+ *                   <ul>
+ *                     <li>TOTP ({@code factorType="totp"}):
+ *                       <ul>
+ *                         <li>{@code createdAt} — {@link Long} epoch-millis timestamp</li>
+ *                         <li>{@code lastUsedAt} — {@link Long} epoch-millis timestamp; absent until first successful verification</li>
+ *                       </ul>
+ *                     </li>
+ *                     <li>Recovery ({@code factorType="recovery"}):
+ *                       <ul>
+ *                         <li>{@code codesRemaining} — {@link Integer} remaining recovery codes</li>
+ *                         <li>{@code createdAt} — {@link Long} epoch-millis timestamp</li>
+ *                         <li>{@code lastUsedAt} — {@link Long} epoch-millis timestamp; absent until first successful verification</li>
+ *                       </ul>
+ *                     </li>
+ *                   </ul>
  */
 public record FactorStatus(boolean enrolled, boolean confirmed, Map<String, Object> attributes) {
 

--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
@@ -208,7 +208,9 @@ public class MfaManager {
     /**
      * Query the enrollment status for a user and factor.
      *
-     * <p>SecretStore calls: {@code load()}.
+     * <p>This delegates to {@link FactorProvider#status(String)} of the registered provider.
+     * The returned {@link FactorStatus#attributes()} map is factor-specific; see {@link FactorStatus}
+     * for the built-in attribute keys.
      *
      * @throws FactorNotRegisteredException if the factor type is not registered
      */


### PR DESCRIPTION
## Summary
Document `MfaManager.status()` and the attribute keys/value types returned by built-in factor providers via `FactorStatus.attributes()`.

Closes #25

## Verification
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)