### PR TITLE
refactor(totp): move EnrollmentContext conversion to boundary helper

### DIFF
--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContext.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContext.java
@@ -1,24 +1,17 @@
 package io.tokido.core.totp;
 
-import io.tokido.core.EnrollmentContext;
-import io.tokido.core.spi.SecretStore;
-
 import java.util.Objects;
 
 /**
  * Type-safe enrollment input for {@link TotpFactorProvider}.
  * <p>
- * Prefer this over raw {@link EnrollmentContext#of(String, Object)} so the account name for the
+ * Prefer this over raw stringly-typed enrollment maps so the account name for the
  * otpauth URI is required at compile time and cannot be mistyped or omitted.
  */
 public record TotpEnrollmentContext(String accountName) {
 
     public TotpEnrollmentContext {
         Objects.requireNonNull(accountName, "accountName");
-    }
-
-    public EnrollmentContext asEnrollmentContext() {
-        return EnrollmentContext.of(SecretStore.Metadata.ACCOUNT_NAME, accountName);
     }
 }
 

--- a/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContexts.java
+++ b/tokido-core-totp/src/main/java/io/tokido/core/totp/TotpEnrollmentContexts.java
@@ -1,0 +1,25 @@
+package io.tokido.core.totp;
+
+import io.tokido.core.EnrollmentContext;
+import io.tokido.core.spi.SecretStore;
+
+import java.util.Objects;
+
+/**
+ * Boundary helpers for converting typed TOTP enrollment inputs into the SPI {@link EnrollmentContext}.
+ */
+public final class TotpEnrollmentContexts {
+
+    private TotpEnrollmentContexts() {}
+
+    public static EnrollmentContext enrollment(String accountName) {
+        Objects.requireNonNull(accountName, "accountName");
+        return EnrollmentContext.of(SecretStore.Metadata.ACCOUNT_NAME, accountName);
+    }
+
+    public static EnrollmentContext enrollment(TotpEnrollmentContext ctx) {
+        Objects.requireNonNull(ctx, "ctx");
+        return enrollment(ctx.accountName());
+    }
+}
+

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -93,7 +93,7 @@ class TotpFactorProviderTest {
     @Test
     void enrollUsesTotpEnrollmentContext() {
         TotpEnrollmentResult result = provider.enroll("user1",
-                new TotpEnrollmentContext("alice@example.com").asEnrollmentContext());
+                TotpEnrollmentContexts.enrollment(new TotpEnrollmentContext("alice@example.com")));
 
         assertTrue(result.secretUri().contains("alice%40example.com"));
     }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpMfaManagerIntegrationTest.java
@@ -20,7 +20,7 @@ class TotpMfaManagerIntegrationTest {
         TotpFactorProvider totp = new TotpFactorProvider(config, store);
         MfaManager mfa = MfaManager.builder().secretStore(store).factor(totp).build();
 
-        mfa.enroll("u1", "totp", new TotpEnrollmentContext("alice@example.com").asEnrollmentContext());
+        mfa.enroll("u1", "totp", TotpEnrollmentContexts.enrollment(new TotpEnrollmentContext("alice@example.com")));
 
         StoredSecret stored = store.inspect("u1", "totp");
         assertNotNull(stored);


### PR DESCRIPTION
## Summary
Remove SPI dependencies from `TotpEnrollmentContext` by moving conversion to a boundary helper (`TotpEnrollmentContexts`).

Closes #26

## Verification
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)