### PR TITLE
feat(recovery): add typed RecoveryEnrollmentContext

### DIFF
--- a/tokido-core-recovery/src/main/java/io/tokido/core/recovery/RecoveryEnrollmentContext.java
+++ b/tokido-core-recovery/src/main/java/io/tokido/core/recovery/RecoveryEnrollmentContext.java
@@ -1,0 +1,11 @@
+package io.tokido.core.recovery;
+
+/**
+ * Type-safe enrollment input for {@link RecoveryCodeProvider}.
+ *
+ * <p>Recovery enrollment currently has no additional inputs, but this record provides
+ * a stable, extensible shape for future enrollment options without relying on untyped maps.
+ */
+public record RecoveryEnrollmentContext() {
+}
+

--- a/tokido-core-recovery/src/main/java/io/tokido/core/recovery/RecoveryEnrollmentContexts.java
+++ b/tokido-core-recovery/src/main/java/io/tokido/core/recovery/RecoveryEnrollmentContexts.java
@@ -1,0 +1,23 @@
+package io.tokido.core.recovery;
+
+import io.tokido.core.EnrollmentContext;
+
+import java.util.Objects;
+
+/**
+ * Boundary helpers for converting typed recovery enrollment inputs into the SPI {@link EnrollmentContext}.
+ */
+public final class RecoveryEnrollmentContexts {
+
+    private RecoveryEnrollmentContexts() {}
+
+    public static EnrollmentContext enrollment() {
+        return EnrollmentContext.empty();
+    }
+
+    public static EnrollmentContext enrollment(RecoveryEnrollmentContext ctx) {
+        Objects.requireNonNull(ctx, "ctx");
+        return enrollment();
+    }
+}
+

--- a/tokido-core-recovery/src/test/java/io/tokido/core/recovery/RecoveryCodeProviderTest.java
+++ b/tokido-core-recovery/src/test/java/io/tokido/core/recovery/RecoveryCodeProviderTest.java
@@ -35,7 +35,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void enrollGeneratesTenCodes() {
-        RecoveryEnrollmentResult result = provider.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult result = provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
 
         List<String> codes = result.codes();
         assertEquals(10, codes.size());
@@ -50,7 +50,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void enrollStoresHashedCodes() {
-        provider.enroll("user1", EnrollmentContext.empty());
+        provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
 
         assertTrue(store.hasSecret("user1", "recovery"));
         StoredSecret stored = store.inspect("user1", "recovery");
@@ -65,7 +65,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void verifyAcceptsValidCode() {
-        RecoveryEnrollmentResult enrollment = provider.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult enrollment = provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
         String firstCode = enrollment.codes().get(0);
 
         RecoveryVerificationResult result = provider.verify("user1", firstCode, VerificationContext.empty());
@@ -75,7 +75,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void verifyConsumesCode() {
-        RecoveryEnrollmentResult enrollment = provider.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult enrollment = provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
         String firstCode = enrollment.codes().get(0);
 
         // First use succeeds
@@ -90,7 +90,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void verifyRejectsInvalidCode() {
-        provider.enroll("user1", EnrollmentContext.empty());
+        provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
 
         RecoveryVerificationResult result = provider.verify("user1", "00000000", VerificationContext.empty());
         assertFalse(result.valid());
@@ -99,7 +99,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void verifyMultipleCodesDecrementsCount() {
-        RecoveryEnrollmentResult enrollment = provider.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult enrollment = provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
 
         for (int i = 0; i < 3; i++) {
             RecoveryVerificationResult result = provider.verify(
@@ -123,7 +123,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void statusEnrolled() {
-        provider.enroll("user1", EnrollmentContext.empty());
+        provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
         FactorStatus status = provider.status("user1");
         assertTrue(status.enrolled());
         assertTrue(status.confirmed()); // recovery codes don't need confirmation
@@ -132,7 +132,7 @@ class RecoveryCodeProviderTest {
 
     @Test
     void statusAfterCodeUse() {
-        RecoveryEnrollmentResult enrollment = provider.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult enrollment = provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
         provider.verify("user1", enrollment.codes().get(0), VerificationContext.empty());
 
         FactorStatus status = provider.status("user1");
@@ -145,7 +145,7 @@ class RecoveryCodeProviderTest {
                 RecoveryConfig.defaults().codeCount(5).codeLength(6).bcryptCost(4),
                 store);
 
-        RecoveryEnrollmentResult result = custom.enroll("user1", EnrollmentContext.empty());
+        RecoveryEnrollmentResult result = custom.enroll("user1", RecoveryEnrollmentContexts.enrollment());
         assertEquals(5, result.codes().size());
         for (String code : result.codes()) {
             assertEquals(6, code.length());


### PR DESCRIPTION
## Summary
Add `RecoveryEnrollmentContext` (and a boundary helper) as a typed enrollment input for recovery codes, matching the TOTP module’s pattern and leaving room for future options.

Closes #27

## Verification
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)