### PR TITLE
feat(engine): add atomic multi-factor enrollment with rollback

### DIFF
--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/FactorEnrollment.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/FactorEnrollment.java
@@ -1,0 +1,20 @@
+package io.tokido.core.engine;
+
+import io.tokido.core.EnrollmentContext;
+
+import java.util.Objects;
+
+/**
+ * One factor enrollment request used by {@link MfaManager#enroll(String, java.util.List)}.
+ *
+ * @param factorType factor identifier (e.g. {@code "totp"}, {@code "recovery"})
+ * @param ctx        enrollment context for the factor
+ */
+public record FactorEnrollment(String factorType, EnrollmentContext ctx) {
+
+    public FactorEnrollment {
+        Objects.requireNonNull(factorType, "factorType");
+        Objects.requireNonNull(ctx, "ctx");
+    }
+}
+

--- a/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
+++ b/tokido-core-engine/src/main/java/io/tokido/core/engine/MfaManager.java
@@ -99,6 +99,48 @@ public class MfaManager {
     }
 
     /**
+     * Atomically enroll a user in multiple factors.
+     *
+     * <p>If any enrollment fails, the engine rolls back by unenrolling any factors that were
+     * already enrolled in this call (best-effort), leaving the store without partial state.
+     *
+     * <p>Pre-check: if any requested factor is already enrolled, this method throws without
+     * writing anything.
+     *
+     * @return enrollment results keyed by factor type, in the same iteration order as input
+     * @throws AlreadyEnrolledException if the user is already enrolled in any requested factor
+     * @throws FactorNotRegisteredException if any factor type is not registered
+     */
+    public Map<String, EnrollmentResult> enroll(String userId, List<FactorEnrollment> enrollments) {
+        Objects.requireNonNull(enrollments, "enrollments");
+        if (enrollments.isEmpty()) {
+            return Map.of();
+        }
+
+        // Validate and pre-check existence so we can fail without partial writes.
+        for (FactorEnrollment e : enrollments) {
+            requireFactor(e.factorType());
+            if (secretStore.exists(userId, e.factorType())) {
+                throw new AlreadyEnrolledException(userId, e.factorType());
+            }
+        }
+
+        LinkedHashMap<String, EnrollmentResult> results = new LinkedHashMap<>();
+        ArrayList<String> attemptedFactorTypes = new ArrayList<>();
+        try {
+            for (FactorEnrollment e : enrollments) {
+                attemptedFactorTypes.add(e.factorType());
+                EnrollmentResult r = enroll(userId, e.factorType(), e.ctx());
+                results.put(e.factorType(), r);
+            }
+            return Map.copyOf(results);
+        } catch (RuntimeException ex) {
+            rollbackEnrollmentsBestEffort(userId, attemptedFactorTypes);
+            throw ex;
+        }
+    }
+
+    /**
      * Confirm a pending enrollment by verifying a credential generated from the new factor.
      *
      * <p>Only applicable to factors where {@code requiresConfirmation()} is true (e.g., TOTP).
@@ -203,6 +245,22 @@ public class MfaManager {
         provider.unenroll(userId);
         secretStore.delete(userId, factorType);
         audit(userId, factorType, "unenrolled");
+    }
+
+    private void rollbackEnrollmentsBestEffort(String userId, List<String> factorTypes) {
+        for (int i = factorTypes.size() - 1; i >= 0; i--) {
+            String factorType = factorTypes.get(i);
+            try {
+                FactorProvider<?, ?> provider = factors.get(factorType);
+                if (provider != null && secretStore.exists(userId, factorType)) {
+                    provider.unenroll(userId);
+                    secretStore.delete(userId, factorType);
+                    audit(userId, factorType, "enroll_rollback");
+                }
+            } catch (RuntimeException ignored) {
+                // Best-effort rollback: do not hide the original enrollment failure.
+            }
+        }
     }
 
     /**

--- a/tokido-core-engine/src/test/java/io/tokido/core/engine/MfaManagerTest.java
+++ b/tokido-core-engine/src/test/java/io/tokido/core/engine/MfaManagerTest.java
@@ -124,6 +124,62 @@ class MfaManagerTest {
         assertEquals(false, stored.metadata().get("confirmed"));
     }
 
+    @Test
+    void enrollMultipleRollsBackOnFailure() {
+        FactorProvider<TestEnrollmentResult, TestVerificationResult> ok = new FactorProvider<>() {
+            @Override public String factorType() { return "ok"; }
+            @Override public boolean requiresConfirmation() { return false; }
+            @Override public TestEnrollmentResult enroll(String userId, EnrollmentContext ctx) {
+                store.store(userId, factorType(), new byte[]{1}, Map.of());
+                return new TestEnrollmentResult("ok");
+            }
+            @Override public TestVerificationResult verify(String userId, String credential, VerificationContext ctx) {
+                return new TestVerificationResult(true, null);
+            }
+            @Override public void unenroll(String userId) {}
+            @Override public FactorStatus status(String userId) { return store.hasSecret(userId, factorType()) ? new FactorStatus(true, true, Map.of()) : FactorStatus.notEnrolled(); }
+        };
+
+        FactorProvider<TestEnrollmentResult, TestVerificationResult> boom = new FactorProvider<>() {
+            @Override public String factorType() { return "boom"; }
+            @Override public boolean requiresConfirmation() { return false; }
+            @Override public TestEnrollmentResult enroll(String userId, EnrollmentContext ctx) {
+                // Simulate provider writing, then throwing.
+                store.store(userId, factorType(), new byte[]{2}, Map.of());
+                throw new RuntimeException("boom");
+            }
+            @Override public TestVerificationResult verify(String userId, String credential, VerificationContext ctx) {
+                return new TestVerificationResult(true, null);
+            }
+            @Override public void unenroll(String userId) {}
+            @Override public FactorStatus status(String userId) { return store.hasSecret(userId, factorType()) ? new FactorStatus(true, true, Map.of()) : FactorStatus.notEnrolled(); }
+        };
+
+        var mfa = buildManager(ok, boom);
+
+        assertThrows(RuntimeException.class, () -> mfa.enroll("user1", java.util.List.of(
+                new FactorEnrollment("ok", EnrollmentContext.empty()),
+                new FactorEnrollment("boom", EnrollmentContext.empty())
+        )));
+
+        assertFalse(store.hasSecret("user1", "ok"));
+        assertFalse(store.hasSecret("user1", "boom"));
+    }
+
+    @Test
+    void enrollMultiplePrecheckAvoidsPartialWrites() {
+        var mfa = buildManager(factor("test-simple", false), factor("test-confirm", true));
+        mfa.enroll("user1", "test-simple", EnrollmentContext.empty());
+
+        assertThrows(AlreadyEnrolledException.class, () -> mfa.enroll("user1", java.util.List.of(
+                new FactorEnrollment("test-simple", EnrollmentContext.empty()),
+                new FactorEnrollment("test-confirm", EnrollmentContext.empty())
+        )));
+
+        // confirm factor should not have been written.
+        assertFalse(store.hasSecret("user1", "test-confirm"));
+    }
+
     // --- Confirmation ---
 
     @Test


### PR DESCRIPTION
## Summary
Add `MfaManager.enroll(userId, List<FactorEnrollment>)` to enroll multiple factors in one call with best-effort rollback on failure.

Closes #24

## Verification
- [x] `mvn verify`

Made with [Cursor](https://cursor.com)