### PR TITLE
chore: Codecov, README coverage badge, and JaCoCo gap tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Build and test with coverage
         run: mvn verify
 
+      - name: Upload coverage to Codecov
+        if: success()
+        continue-on-error: true
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          files: |
+            **/target/site/jacoco/jacoco.xml
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,11 @@ jobs:
       - name: Build and test with coverage
         run: mvn verify
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage reports to Codecov
         if: success()
-        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
           files: |
             **/target/site/jacoco/jacoco.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,10 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: success()
-        continue-on-error: true
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           files: |
             **/target/site/jacoco/jacoco.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees/
 target/
 *.class
 *.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,8 @@ tokido-core has a deliberately minimal style. There is no formatter enforced by 
 
 ## CI / GitHub Actions
 
+The workflow runs `mvn verify`, uploads JaCoCo XML to [Codecov](https://codecov.io/gh/tokido-io/tokido-core), and attaches HTML reports as workflow artifacts. Maintainers: add a `CODECOV_TOKEN` repository secret so uploads succeed (the step is non-blocking if the secret is missing). Connect the GitHub repo in the Codecov UI to enable PR comments and the README coverage badge.
+
 JavaScript actions that run on **Node 24** need a GitHub Actions runner that bundles Node 24 support. **Self-hosted runners** must run [`actions/runner`](https://github.com/actions/runner) **v2.328.0 or newer**; older runners cannot execute those actions. GitHub documents this in the [Node 20 deprecation / Node 24 rollout changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ tokido-core has a deliberately minimal style. There is no formatter enforced by 
 
 ## CI / GitHub Actions
 
-The workflow runs `mvn verify`, uploads JaCoCo XML to [Codecov](https://codecov.io/gh/tokido-io/tokido-core), and attaches HTML reports as workflow artifacts. Maintainers: add a `CODECOV_TOKEN` repository secret so uploads succeed (the step is non-blocking if the secret is missing). Connect the GitHub repo in the Codecov UI to enable PR comments and the README coverage badge.
+The workflow runs `mvn verify`, uploads JaCoCo XML to [Codecov](https://codecov.io/gh/tokido-io/tokido-core), and attaches HTML reports as workflow artifacts. The Codecov step uses the `CODECOV_TOKEN` repository secret and fails the job if the upload errors. Connect the GitHub repo in the Codecov UI to enable PR comments and the README coverage badge.
 
 JavaScript actions that run on **Node 24** need a GitHub Actions runner that bundles Node 24 support. **Self-hosted runners** must run [`actions/runner`](https://github.com/actions/runner) **v2.328.0 or newer**; older runners cannot execute those actions. GitHub documents this in the [Node 20 deprecation / Node 24 rollout changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Production-grade MFA toolkit for Java. TOTP, recovery codes, extensible factors. GraalVM native-image ready.
 
 [![CI](https://github.com/tokido-io/tokido-core/actions/workflows/ci.yml/badge.svg)](https://github.com/tokido-io/tokido-core/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/tokido-io/tokido-core/graph/badge.svg)](https://codecov.io/gh/tokido-io/tokido-core)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 ## Why tokido-core?
@@ -97,6 +98,12 @@ mvn verify
 ```
 
 Requires Java 21+.
+
+## Coverage
+
+Line coverage is measured with [JaCoCo](https://www.jacoco.org/jacoco/) during `mvn verify` (minimum **90%** per module bundle). HTML reports are written under each module, for example `tokido-core-engine/target/site/jacoco/index.html`.
+
+CI publishes reports to [Codecov](https://codecov.io/gh/tokido-io/tokido-core) (interactive tree and history). The badge above tracks default-branch coverage; PRs get a diff once the repository is connected to Codecov.
 
 ## Used in production by
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        informational: true

--- a/tokido-core-engine/src/test/java/io/tokido/core/engine/MfaManagerTest.java
+++ b/tokido-core-engine/src/test/java/io/tokido/core/engine/MfaManagerTest.java
@@ -7,7 +7,9 @@ import io.tokido.core.test.InMemorySecretStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -180,6 +182,68 @@ class MfaManagerTest {
         assertFalse(store.hasSecret("user1", "test-confirm"));
     }
 
+    @Test
+    void enrollEmptyListReturnsEmptyMap() {
+        var mfa = buildManager(factor("a", false));
+        assertTrue(mfa.enroll("user1", List.of()).isEmpty());
+    }
+
+    @Test
+    void enrollMultipleAllSucceedReturnsResults() {
+        var mfa = buildManager(factor("a", false), factor("b", false));
+        Map<String, EnrollmentResult> results = mfa.enroll("user1", List.of(
+                new FactorEnrollment("a", EnrollmentContext.empty()),
+                new FactorEnrollment("b", EnrollmentContext.empty())
+        ));
+        assertEquals(2, results.size());
+        assertTrue(store.hasSecret("user1", "a"));
+        assertTrue(store.hasSecret("user1", "b"));
+    }
+
+    @Test
+    void enrollMultipleRollbackIgnoresUnenrollFailure() {
+        FactorProvider<TestEnrollmentResult, TestVerificationResult> ok = new FactorProvider<>() {
+            @Override public String factorType() { return "ok"; }
+            @Override public boolean requiresConfirmation() { return false; }
+            @Override public TestEnrollmentResult enroll(String userId, EnrollmentContext ctx) {
+                store.store(userId, factorType(), new byte[]{1}, Map.of());
+                return new TestEnrollmentResult("ok");
+            }
+            @Override public TestVerificationResult verify(String userId, String credential, VerificationContext ctx) {
+                return new TestVerificationResult(true, null);
+            }
+            @Override public void unenroll(String userId) {
+                throw new RuntimeException("simulated rollback unenroll failure");
+            }
+            @Override public FactorStatus status(String userId) {
+                return store.hasSecret(userId, factorType()) ? new FactorStatus(true, true, Map.of()) : FactorStatus.notEnrolled();
+            }
+        };
+
+        FactorProvider<TestEnrollmentResult, TestVerificationResult> boom = new FactorProvider<>() {
+            @Override public String factorType() { return "boom"; }
+            @Override public boolean requiresConfirmation() { return false; }
+            @Override public TestEnrollmentResult enroll(String userId, EnrollmentContext ctx) {
+                store.store(userId, factorType(), new byte[]{2}, Map.of());
+                throw new RuntimeException("boom");
+            }
+            @Override public TestVerificationResult verify(String userId, String credential, VerificationContext ctx) {
+                return new TestVerificationResult(true, null);
+            }
+            @Override public void unenroll(String userId) {}
+            @Override public FactorStatus status(String userId) {
+                return store.hasSecret(userId, factorType()) ? new FactorStatus(true, true, Map.of()) : FactorStatus.notEnrolled();
+            }
+        };
+
+        var mfa = buildManager(ok, boom);
+
+        assertThrows(RuntimeException.class, () -> mfa.enroll("user1", List.of(
+                new FactorEnrollment("ok", EnrollmentContext.empty()),
+                new FactorEnrollment("boom", EnrollmentContext.empty())
+        )));
+    }
+
     // --- Confirmation ---
 
     @Test
@@ -263,6 +327,7 @@ class MfaManagerTest {
 
         VerificationResult result = mfa.verify("user1", "test-confirm", "valid");
         assertFalse(result.valid());
+        assertEquals(Optional.of("unconfirmed"), result.failureReason());
     }
 
     @Test

--- a/tokido-core-recovery/src/test/java/io/tokido/core/recovery/RecoveryCodeProviderTest.java
+++ b/tokido-core-recovery/src/test/java/io/tokido/core/recovery/RecoveryCodeProviderTest.java
@@ -151,4 +151,36 @@ class RecoveryCodeProviderTest {
             assertEquals(6, code.length());
         }
     }
+
+    @Test
+    void defaultConfigConstructor() {
+        RecoveryCodeProvider p = new RecoveryCodeProvider(store);
+        RecoveryEnrollmentResult result = p.enroll("user1", RecoveryEnrollmentContexts.enrollment());
+        assertEquals(10, result.codes().size());
+    }
+
+    @Test
+    void enrollmentWithTypedContext() {
+        RecoveryEnrollmentResult result = provider.enroll("user1",
+                RecoveryEnrollmentContexts.enrollment(new RecoveryEnrollmentContext()));
+        assertEquals(10, result.codes().size());
+    }
+
+    @Test
+    void enrollmentTypedContextRejectsNull() {
+        assertThrows(NullPointerException.class, () ->
+                RecoveryEnrollmentContexts.enrollment(null));
+    }
+
+    @Test
+    void recoveryEnrollmentContextInstantiation() {
+        assertNotNull(new RecoveryEnrollmentContext());
+    }
+
+    @Test
+    void unenrollIsNoOp() {
+        provider.enroll("user1", RecoveryEnrollmentContexts.enrollment());
+        provider.unenroll("user1");
+        assertTrue(store.hasSecret("user1", "recovery"));
+    }
 }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/QrCodeGeneratorTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/QrCodeGeneratorTest.java
@@ -29,4 +29,12 @@ class QrCodeGeneratorTest {
         assertNotNull(base64);
         assertFalse(base64.isEmpty());
     }
+
+    @Test
+    void toPngBase64WrapsEncoderFailures() {
+        // Exceeds maximum QR capacity so ZXing throws; should surface as RuntimeException with a stable message.
+        String tooLong = "x".repeat(10_000);
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> QrCodeGenerator.toPngBase64(tooLong));
+        assertEquals("QR code generation failed", ex.getMessage());
+    }
 }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpAlgorithmTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpAlgorithmTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * RFC 6238 Appendix B test vectors.
@@ -88,5 +89,12 @@ class TotpAlgorithmTest {
         TotpConfig config = TotpConfig.defaults();
         int code = TotpAlgorithm.generate(SEED_SHA1, 1, config);
         assertEquals(287082, code); // 6-digit default
+    }
+
+    @Test
+    void generateThrowsWhenMacAlgorithmInvalid() {
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> TotpAlgorithm.generate(SEED_SHA1, 1L, "NoSuchHmacAlgorithm", 6));
+        assertEquals("TOTP computation failed", ex.getMessage());
     }
 }

--- a/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
+++ b/tokido-core-totp/src/test/java/io/tokido/core/totp/TotpFactorProviderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,6 +70,54 @@ class TotpFactorProviderTest {
         assertTrue(ex.secretUri().startsWith("otpauth://totp/"));
         assertEquals("simulated QR failure", ex.getCause().getMessage());
         assertFalse(store.hasSecret("user1", "totp"));
+    }
+
+    @Test
+    void enrollPropagatesTotpQrCodeGenerationException() {
+        TotpFactorProvider failing = new TotpFactorProvider(
+                TotpConfig.defaults().issuer("TestApp"),
+                store,
+                uri -> {
+                    throw new TotpQrCodeGenerationException(uri, new RuntimeException("inner"));
+                });
+
+        TotpQrCodeGenerationException ex = assertThrows(TotpQrCodeGenerationException.class,
+                () -> failing.enroll("user1", EnrollmentContext.empty()));
+
+        assertTrue(ex.secretUri().startsWith("otpauth://totp/"));
+        assertEquals("inner", ex.getCause().getMessage());
+        assertFalse(store.hasSecret("user1", "totp"));
+    }
+
+    @Test
+    void defaultSecretStoreConstructorUsesDefaultTotpConfig() {
+        TotpFactorProvider p = new TotpFactorProvider(store);
+        assertEquals("totp", p.factorType());
+        TotpEnrollmentResult r = p.enroll("user1", EnrollmentContext.empty());
+        assertTrue(r.secretUri().contains("issuer="));
+    }
+
+    @Test
+    void enrollUsesLegacyAccountNameProperty() {
+        TotpEnrollmentResult result = provider.enroll("user1",
+                EnrollmentContext.of("accountName", "legacy@example.com"));
+        assertTrue(result.secretUri().contains("legacy%40example.com"));
+    }
+
+    @Test
+    void statusReflectsConfirmationMetadataWhenRequired() {
+        TotpFactorProvider confirmRequired = new TotpFactorProvider(
+                TotpConfig.defaults().requiresConfirmation(true), store);
+        confirmRequired.enroll("user1", EnrollmentContext.empty());
+
+        FactorStatus pending = confirmRequired.status("user1");
+        assertTrue(pending.enrolled());
+        assertFalse(pending.confirmed());
+
+        store.update("user1", "totp", Map.of(SecretStore.Metadata.CONFIRMED, true));
+
+        FactorStatus after = confirmRequired.status("user1");
+        assertTrue(after.confirmed());
     }
 
     @Test


### PR DESCRIPTION
Adds Codecov upload after `mvn verify`, a README badge linking to the interactive Codecov report, and targeted tests to cover previously missed branches (multi-factor enroll, recovery/TOTP helpers, QR/TOTP edge cases). Includes `codecov.yml` aligned with the existing 90% JaCoCo gate and CONTRIBUTING notes for maintainers.

**Follow-up:** Ensure the Codecov GitHub app is installed for the org/repo if PR comments are desired.

Made with [Cursor](https://cursor.com)