### PR TITLE
fix(ci): pass GPG_PASSPHRASE to release Build-and-verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
 
       - name: Build and verify
         run: mvn verify -P release -DskipITs
+        env:
+          # The release profile triggers maven-gpg-plugin during the verify
+          # phase, which the parent settings.xml resolves via ${env.GPG_PASSPHRASE}.
+          # Without this env block, the verify step fails with "Bad passphrase".
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Verify source and Javadoc artifacts
         run: |


### PR DESCRIPTION
## Why

The 0.1.0-M0 release workflow run failed at \`gpg: signing failed: Bad passphrase\` during the Build-and-verify step. Investigation:

1. Last successful release was 1.1.0 (62f0d93, 2026-04-20). At that commit, \`maven-javadoc-plugin\` was in the always-on \`<build><plugins>\` block, so \`mvn verify\` (no profile) generated javadoc.jar without triggering signing. Signing happened only during \`mvn deploy -P release\` which had \`GPG_PASSPHRASE\` in env.

2. Commit 8ca334c ("ci: pin actions and tighten workflow permissions", 2026-04-20) moved \`maven-javadoc-plugin\` into the \`release\` profile AND changed the workflow's Build-and-verify step from \`mvn verify\` to \`mvn verify -P release\` — but did not add \`GPG_PASSPHRASE\` env to that step. That change has never run during a real release until 0.1.0-M0; the latent bug surfaced now.

The keys are correct. The workflow shape is wrong.

## Fix

One env block on the Build-and-verify step. Both signing-active steps (verify + deploy) now have \`GPG_PASSPHRASE\` available.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-tag 0.1.0-M0, recreate the release, watch release.yml succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)