### PR TITLE
fix(m0): correct skipPublishing property for conformance module

### DIFF
--- a/tokido-core-identity-conformance/pom.xml
+++ b/tokido-core-identity-conformance/pom.xml
@@ -18,7 +18,12 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <central.publishing.skip>true</central.publishing.skip>
+        <!--
+            central-publishing-maven-plugin's actual user property is `skipPublishing`,
+            not `central.publishing.skip`. The wrong name is a no-op, and the plugin
+            still attempts to publish the conformance jar.
+        -->
+        <skipPublishing>true</skipPublishing>
         <gpg.skip>true</gpg.skip>
     </properties>
 


### PR DESCRIPTION
Third release-prep fix. The conformance module pom used `<central.publishing.skip>` which is not a recognized property of central-publishing-maven-plugin (the actual property is `<skipPublishing>`). The wrong name was silently ignored, so the plugin tried to publish the conformance jar to Maven Central and failed bundle validation.

Verified locally: `mvn help:effective-pom -pl tokido-core-identity-conformance -P release | grep -A 1 skipPublishing` shows `<skipPublishing>true</skipPublishing>` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)