### PR TITLE
feat: M1 — Core SPI Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Production-grade MFA toolkit for Java. TOTP, recovery codes, extensible factors.
 
 ## OIDC extension status (in development — alpha)
 
-The OIDC extension is being built across six releases (M0 → M5). The current release is **`0.1.0-M0`** — scaffolding and conformance harness only; no engine code yet.
+The OIDC extension is being built across six releases (M0 → M5). The current release is **`0.1.0-M1`** — the **public unblock event for downstream framework adapters** (`tokido-spring`, `tokido-quarkus`). All six core storage SPIs and the full protocol value-type surface are now `@API(STABLE)`.
 
-**OIDC basic conformance: 0/N** (M0 baseline — stub adapter returns `501 Not Implemented` for all endpoints; conformance pass-rate climbs as the engine implementation lands at M2 onward.)
+**OIDC basic conformance: 0/35** (M1 — engine façade still throws `UnsupportedOperationException`; conformance pass-rate climbs as engine handlers land at M2.)
 
 | Module | Introduced | API status | Coverage | Notes |
 |---|---|---|---|---|
-| `tokido-core-identity-api` | M0 | empty skeleton | n/a | SPIs and protocol value types land at M1 |
-| `tokido-core-identity-engine` | M0 | empty skeleton | n/a | Engine façade and handlers land at M1–M2 |
+| `tokido-core-identity-api` | M0 | `@API(STABLE)` (M1+) | ≥ 90% | Six core SPIs (`ClientStore`, `ResourceStore`, `TokenStore`, `UserStore`, `ConsentStore`, `KeyStore`), protocol request/result value types, `AuthenticationState`, `DiscoveryDocument`, `JsonWebKey`/`JsonWebKeySet`. Surface frozen by `revapi-maven-plugin`; breaking changes require an ADR per ADR-0006. |
+| `tokido-core-identity-engine` | M0 | `@API(STABLE)` façade; impl at M2 | ≥ 90% | `IdentityEngine` Builder + method signatures committed; every method throws `UnsupportedOperationException` until M2. `TokenSigner` and `EventSink` SPIs locked. |
 | `tokido-core-identity-jwt` | M2 (placeholder pom in M0) | not yet introduced | n/a | Nimbus-backed JWT signing; lands at M2 |
 | `tokido-core-identity-broker` | M3 (placeholder pom in M0) | not yet introduced | n/a | OIDC RP federation; lands at M3 |
 | `tokido-core-identity-mfa` | M4 (placeholder pom in M0) | not yet introduced | n/a | Bridge to existing MFA modules; lands at M4 |
 
-> Coverage gates are intentionally suppressed in M0 (modules contain no Java sources yet); they re-engage at M1 when SPIs and protocol value types land.
+> Coverage gates are active for `identity-api` and `identity-engine` from M1; the remaining identity modules' gates re-engage as their first main sources land in M2/M3/M4.
 
 The release cadence and milestone definitions are documented in [ADR-0004](docs/adr/0004-release-cadence.md). See `docs/adr/` for the full architectural decision record.
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,18 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit-junit5</artifactId>
+                <version>1.3.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.26.3</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -136,6 +148,18 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.revapi</groupId>
+                    <artifactId>revapi-maven-plugin</artifactId>
+                    <version>0.15.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-java</artifactId>
+                            <version>0.28.4</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -206,16 +230,20 @@
                                 <goals><goal>jar</goal></goals>
                                 <configuration>
                                     <!--
-                                        Identity modules at M0 contain only package-info.java placeholders.
-                                        Javadoc fails with "No public or protected classes found to document"
-                                        but Maven Central still requires a *-javadoc.jar for every artifact.
-                                        failOnError=false lets the build continue; the plugin produces a
-                                        minimal but valid jar. As real public types land in M1+, this becomes
-                                        a no-op in normal operation but still guards against future empty-module
-                                        regressions.
+                                        Identity modules with @API(STABLE) types must ship complete
+                                        Javadoc. failOnWarnings=true + doclint=all,-missing catches
+                                        structural javadoc errors on locked types. failOnError=false
+                                        is retained because identity modules are empty placeholders at
+                                        Task 1 (javadoc hard-errors "No public or protected classes
+                                        found" which failOnError=false suppresses). The -missing
+                                        exemption is the fallback noted in the task spec; individual
+                                        identity module poms will override with doclint=all once
+                                        @API(STABLE) types land in Task 2+.
                                     -->
                                     <failOnError>false</failOnError>
-                                    <doclint>none</doclint>
+                                    <failOnWarnings>true</failOnWarnings>
+                                    <doclint>all,-missing</doclint>
+                                    <quiet>true</quiet>
                                 </configuration>
                             </execution>
                         </executions>

--- a/tokido-core-identity-api/pom.xml
+++ b/tokido-core-identity-api/pom.xml
@@ -56,6 +56,32 @@
                     <quiet>true</quiet>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>api-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <!--
+                                Baseline: latest released version on Maven Central.
+                                Until the first 0.1.0-MX release exists on Central, the
+                                plugin has nothing to compare against — skipWhenNoOldArtifacts
+                                keeps the build green during M1's verify, then engages
+                                automatically once 0.1.0-M1 publishes. ADR-0006 requires
+                                breaking changes to be accompanied by an ADR.
+                            -->
+                            <oldVersion>RELEASE</oldVersion>
+                            <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+                            <skipWhenNoOldArtifacts>true</skipWhenNoOldArtifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/tokido-core-identity-api/pom.xml
+++ b/tokido-core-identity-api/pom.xml
@@ -26,21 +26,35 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!--
+                identity-api ships @API(STABLE) types whose Javadoc must be
+                complete (master plan §M1 acceptance criterion). Override
+                parent-level loose javadoc with strict settings: failOnError=true
+                so missing Javadoc on a public type fails the build, doclint=all
+                so structural problems also fail.
+            -->
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <failOnError>true</failOnError>
+                    <failOnWarnings>true</failOnWarnings>
+                    <doclint>all</doclint>
+                    <quiet>true</quiet>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyMaterial.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyMaterial.java
@@ -1,0 +1,23 @@
+package io.tokido.core.identity.key;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * Opaque signing-key material — typically a serialized PEM, JWK, or HSM handle —
+ * paired with the algorithm it can sign with. The {@code bytes} array is the
+ * caller's responsibility to keep confidential; this record does not copy or
+ * scrub it.
+ *
+ * @param bytes raw key material; non-null
+ * @param alg   algorithm this material is intended for; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record KeyMaterial(byte[] bytes, SignatureAlgorithm alg) {
+
+    public KeyMaterial {
+        Objects.requireNonNull(bytes, "bytes");
+        Objects.requireNonNull(alg, "alg");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyState.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyState.java
@@ -1,0 +1,21 @@
+package io.tokido.core.identity.key;
+
+import org.apiguardian.api.API;
+
+/**
+ * Lifecycle state of a signing key.
+ *
+ * <ul>
+ *   <li>{@link #ACTIVE} — used for new signatures, present in JWKS.</li>
+ *   <li>{@link #RETIRED} — no new signatures, still present in JWKS so
+ *       previously-issued tokens validate during the rotation grace window
+ *       (ADR-0007, M2).</li>
+ * </ul>
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public enum KeyState {
+    /** Eligible for new signatures and present in the JWKS endpoint. */
+    ACTIVE,
+    /** No new signatures, still in JWKS so prior tokens validate. */
+    RETIRED
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/KeyStore.java
@@ -1,0 +1,38 @@
+package io.tokido.core.identity.key;
+
+import org.apiguardian.api.API;
+
+import java.util.Set;
+
+/**
+ * Source of signing keys for the engine.
+ *
+ * <p>Implementations may serve keys from in-memory collections, an HSM,
+ * a cloud KMS, or a database. The engine treats this SPI as read-only
+ * during normal request processing; key rotation is an admin op that
+ * is not part of the M1 lock (lands at M2 with {@code KeyRotationPolicy}
+ * per ADR-0007).
+ *
+ * <p>Thread-safety: implementations must be safe for concurrent reads
+ * across many request threads.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface KeyStore {
+
+    /**
+     * Return the active signing key for the given algorithm.
+     *
+     * @param alg algorithm requested by the engine
+     * @return active key; never null
+     * @throws IllegalStateException if no active key exists for the algorithm
+     */
+    SigningKey activeSigningKey(SignatureAlgorithm alg);
+
+    /**
+     * Return every key the store knows about (active and retired).
+     * Used by the JWKS endpoint to publish the verification key set.
+     *
+     * @return non-null, possibly empty, immutable set
+     */
+    Set<SigningKey> allKeys();
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/SignatureAlgorithm.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/SignatureAlgorithm.java
@@ -1,0 +1,17 @@
+package io.tokido.core.identity.key;
+
+import org.apiguardian.api.API;
+
+/**
+ * JWS signature algorithms supported by the engine, named per RFC 7518.
+ * The wire-protocol value matches the enum name.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public enum SignatureAlgorithm {
+    /** RFC 7518 — RSASSA-PKCS1-v1_5 using SHA-256. */
+    RS256,
+    /** RFC 7518 — ECDSA using P-256 and SHA-256. */
+    ES256,
+    /** RFC 8037 — Edwards-curve Digital Signature Algorithm (Ed25519). */
+    EDDSA
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/SigningKey.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/key/SigningKey.java
@@ -1,0 +1,46 @@
+package io.tokido.core.identity.key;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A signing key with full lifecycle metadata.
+ *
+ * @param kid       JWS key id, non-null and non-blank
+ * @param alg       algorithm, must match {@code material.alg()}
+ * @param material  key bytes
+ * @param state     {@link KeyState#ACTIVE} for the current signing key,
+ *                  {@link KeyState#RETIRED} for keys still in JWKS for verification
+ * @param notBefore start of validity (inclusive)
+ * @param notAfter  end of validity (exclusive); must be after {@code notBefore}
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record SigningKey(String kid,
+                         SignatureAlgorithm alg,
+                         KeyMaterial material,
+                         KeyState state,
+                         Instant notBefore,
+                         Instant notAfter) {
+
+    public SigningKey {
+        Objects.requireNonNull(kid, "kid");
+        if (kid.isBlank()) {
+            throw new IllegalArgumentException("kid must not be blank");
+        }
+        Objects.requireNonNull(alg, "alg");
+        Objects.requireNonNull(material, "material");
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(notBefore, "notBefore");
+        Objects.requireNonNull(notAfter, "notAfter");
+        if (alg != material.alg()) {
+            throw new IllegalArgumentException(
+                    "key alg " + alg + " does not match material alg " + material.alg());
+        }
+        if (!notAfter.isAfter(notBefore)) {
+            throw new IllegalArgumentException(
+                    "notAfter (" + notAfter + ") must be after notBefore (" + notBefore + ")");
+        }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthenticationState.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthenticationState.java
@@ -1,0 +1,41 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The framework adapter's representation of "who the browser session says
+ * is logged in". The engine reads this on every authorize call to decide
+ * whether to short-circuit, prompt for login, or require step-up.
+ *
+ * @param subjectId       authenticated user's subject id; {@code null} for anonymous
+ * @param authenticatedAt when the session was authenticated; {@code null} for anonymous
+ * @param amr             AMR values satisfied so far ({@code "pwd"}, {@code "otp"}, ...); null becomes empty
+ * @param acr             current ACR satisfied; {@code null} if no ACR has been pinned
+ * @param session         opaque session attributes the adapter wishes to round-trip; null becomes empty
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record AuthenticationState(
+        String subjectId,
+        Instant authenticatedAt,
+        Set<String> amr,
+        String acr,
+        Map<String, String> session) {
+
+    public AuthenticationState {
+        amr = amr == null ? Set.of() : Set.copyOf(amr);
+        session = session == null ? Map.of() : Map.copyOf(session);
+    }
+
+    /**
+     * Sentinel for unauthenticated requests.
+     *
+     * @return an AuthenticationState with all nulls and empty collections
+     */
+    public static AuthenticationState anonymous() {
+        return new AuthenticationState(null, null, Set.of(), null, Map.of());
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthorizeRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthorizeRequest.java
@@ -1,0 +1,63 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * OIDC authorize request. Maps roughly 1:1 with the OAuth 2.0 / OIDC
+ * authorize endpoint query parameters (RFC 6749 §4.1.1, OIDC Core §3.1.2).
+ * Framework adapters parse the incoming HTTP request and build this record;
+ * the engine consumes it.
+ *
+ * <p>Nullability: all object fields are nullable except {@code clientId}
+ * (must be non-blank). Engine handlers validate semantics (presence-when-
+ * required, length, charset) and emit {@link AuthorizeResult.Error} on bad
+ * input.
+ *
+ * @param clientId            client identifier; non-null and non-blank
+ * @param responseType        OAuth response_type; nullable, validated by engine
+ * @param redirectUri         redirect_uri; nullable
+ * @param scopes              requested scopes; null becomes empty set
+ * @param state               opaque state for CSRF protection; nullable
+ * @param nonce               OIDC nonce; nullable
+ * @param codeChallenge       PKCE code_challenge; nullable
+ * @param codeChallengeMethod PKCE code_challenge_method ({@code "plain"}, {@code "S256"}); nullable
+ * @param responseMode        response_mode ({@code "query"}, {@code "fragment"}, {@code "form_post"}); nullable
+ * @param acrValues           requested ACR values; null becomes empty set
+ * @param maxAge              max age for re-authentication, in seconds; nullable
+ * @param prompt              OIDC prompt parameter ({@code "none"}, {@code "login"}, ...); nullable
+ * @param loginHint           OIDC login_hint; nullable
+ * @param uiLocales           OIDC ui_locales; nullable
+ * @param additional          additional adapter-supplied parameters; null becomes empty map
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record AuthorizeRequest(
+        String clientId,
+        String responseType,
+        String redirectUri,
+        Set<String> scopes,
+        String state,
+        String nonce,
+        String codeChallenge,
+        String codeChallengeMethod,
+        String responseMode,
+        Set<String> acrValues,
+        Long maxAge,
+        String prompt,
+        String loginHint,
+        String uiLocales,
+        Map<String, String> additional) {
+
+    public AuthorizeRequest {
+        Objects.requireNonNull(clientId, "clientId");
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId must not be blank");
+        }
+        scopes = scopes == null ? Set.of() : Set.copyOf(scopes);
+        acrValues = acrValues == null ? Set.of() : Set.copyOf(acrValues);
+        additional = additional == null ? Map.of() : Map.copyOf(additional);
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthorizeResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/AuthorizeResult.java
@@ -1,0 +1,96 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Outcome of {@code IdentityEngine.authorize}. Framework adapters pattern-match
+ * on the variant and translate to the appropriate HTTP response (302 for
+ * {@link Redirect}, 400 for {@link Error}, render login UI for
+ * {@link LoginRequired}, etc.).
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface AuthorizeResult
+        permits AuthorizeResult.Redirect,
+                AuthorizeResult.Error,
+                AuthorizeResult.LoginRequired,
+                AuthorizeResult.ConsentRequired,
+                AuthorizeResult.MfaRequired {
+
+    /**
+     * Redirect the browser to {@code redirectUri} with {@code params} attached
+     * (typically as query string for {@code response_mode=query} or fragment
+     * for {@code response_mode=fragment}). The adapter chooses based on
+     * the request's {@code response_mode}.
+     *
+     * @param redirectUri target URI; non-null
+     * @param params      params to attach; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Redirect(URI redirectUri, Map<String, String> params) implements AuthorizeResult {
+        public Redirect {
+            Objects.requireNonNull(redirectUri, "redirectUri");
+            params = Map.copyOf(Objects.requireNonNull(params, "params"));
+        }
+    }
+
+    /**
+     * Error response. {@code code} is a wire-format error code (e.g.,
+     * {@code "invalid_request"}, {@code "unauthorized_client"}). {@code state}
+     * is echoed from the request when present.
+     *
+     * @param code        wire error code; non-null and non-blank
+     * @param description optional human-readable description; nullable
+     * @param state       echoed state; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Error(String code, String description, String state) implements AuthorizeResult {
+        public Error {
+            Objects.requireNonNull(code, "code");
+            if (code.isBlank()) {
+                throw new IllegalArgumentException("code must not be blank");
+            }
+        }
+    }
+
+    /**
+     * End-user authentication is required. The adapter renders the login UI.
+     *
+     * @param reason optional reason for the prompt; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record LoginRequired(String reason) implements AuthorizeResult {}
+
+    /**
+     * End-user consent is required for {@code requestedScopes}.
+     *
+     * @param requestedScopes scopes that need consent; non-null
+     * @param state           echoed state; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record ConsentRequired(Set<String> requestedScopes, String state) implements AuthorizeResult {
+        public ConsentRequired {
+            requestedScopes = Set.copyOf(Objects.requireNonNull(requestedScopes, "requestedScopes"));
+        }
+    }
+
+    /**
+     * MFA / step-up authentication is required. The {@code requiredAcr}
+     * carries the {@code acr} values from the authorize request that the
+     * current session does not yet satisfy. The adapter renders an MFA
+     * challenge and resumes via a follow-up authorize call (M4).
+     *
+     * @param requiredAcr ACR values needed; non-null
+     * @param state       echoed state; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record MfaRequired(Set<String> requiredAcr, String state) implements AuthorizeResult {
+        public MfaRequired {
+            requiredAcr = Set.copyOf(Objects.requireNonNull(requiredAcr, "requiredAcr"));
+        }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/DiscoveryDocument.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/DiscoveryDocument.java
@@ -1,0 +1,74 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * OIDC discovery / OAuth 2.0 authorization-server metadata. Built by
+ * {@code IdentityEngine.discovery()} and consumed at the
+ * {@code /.well-known/openid-configuration} endpoint.
+ *
+ * <p>Mandatory fields are typed; less-common metadata fields live in
+ * {@code additionalParameters}, mirroring the JWK pattern.
+ *
+ * @param issuer                              issuer identifier; non-null
+ * @param authorizationEndpoint               authorize endpoint; non-null
+ * @param tokenEndpoint                       token endpoint; non-null
+ * @param userinfoEndpoint                    userinfo endpoint; nullable (only when supported)
+ * @param jwksUri                             JWKS endpoint; non-null
+ * @param introspectionEndpoint               introspection endpoint; nullable
+ * @param revocationEndpoint                  revocation endpoint; nullable
+ * @param endSessionEndpoint                  end-session endpoint; nullable
+ * @param responseTypesSupported              non-null
+ * @param grantTypesSupported                 non-null
+ * @param subjectTypesSupported               non-null
+ * @param idTokenSigningAlgValuesSupported    non-null
+ * @param scopesSupported                     null becomes empty
+ * @param tokenEndpointAuthMethodsSupported   null becomes empty
+ * @param claimsSupported                     null becomes empty
+ * @param additionalParameters                non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record DiscoveryDocument(
+        URI issuer,
+        URI authorizationEndpoint,
+        URI tokenEndpoint,
+        URI userinfoEndpoint,
+        URI jwksUri,
+        URI introspectionEndpoint,
+        URI revocationEndpoint,
+        URI endSessionEndpoint,
+        Set<String> responseTypesSupported,
+        Set<String> grantTypesSupported,
+        Set<String> subjectTypesSupported,
+        Set<String> idTokenSigningAlgValuesSupported,
+        Set<String> scopesSupported,
+        Set<String> tokenEndpointAuthMethodsSupported,
+        Set<String> claimsSupported,
+        Map<String, Object> additionalParameters) {
+
+    public DiscoveryDocument {
+        Objects.requireNonNull(issuer, "issuer");
+        Objects.requireNonNull(authorizationEndpoint, "authorizationEndpoint");
+        Objects.requireNonNull(tokenEndpoint, "tokenEndpoint");
+        Objects.requireNonNull(jwksUri, "jwksUri");
+        responseTypesSupported = Set.copyOf(Objects.requireNonNull(
+                responseTypesSupported, "responseTypesSupported"));
+        grantTypesSupported = Set.copyOf(Objects.requireNonNull(
+                grantTypesSupported, "grantTypesSupported"));
+        subjectTypesSupported = Set.copyOf(Objects.requireNonNull(
+                subjectTypesSupported, "subjectTypesSupported"));
+        idTokenSigningAlgValuesSupported = Set.copyOf(Objects.requireNonNull(
+                idTokenSigningAlgValuesSupported, "idTokenSigningAlgValuesSupported"));
+        scopesSupported = scopesSupported == null ? Set.of() : Set.copyOf(scopesSupported);
+        tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported == null
+                ? Set.of() : Set.copyOf(tokenEndpointAuthMethodsSupported);
+        claimsSupported = claimsSupported == null ? Set.of() : Set.copyOf(claimsSupported);
+        additionalParameters = Map.copyOf(Objects.requireNonNull(
+                additionalParameters, "additionalParameters"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/EndSessionRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/EndSessionRequest.java
@@ -1,0 +1,18 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+/**
+ * OIDC end-session (logout) request (OIDC Session Mgmt §5).
+ *
+ * <p>{@code idTokenHint} and {@code postLogoutRedirectUri} are both nullable
+ * per spec; engine validates {@code idTokenHint} shape when present.
+ *
+ * @param idTokenHint           optional ID token hint; nullable
+ * @param postLogoutRedirectUri optional post-logout redirect URI; nullable
+ * @param state                 optional state echoed back; nullable
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record EndSessionRequest(String idTokenHint, String postLogoutRedirectUri, String state) {
+    // All fields nullable; no validation here.
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/EndSessionResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/EndSessionResult.java
@@ -1,0 +1,41 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+
+/** Outcome of {@code IdentityEngine.endSession}. */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface EndSessionResult permits EndSessionResult.Redirect, EndSessionResult.Done, EndSessionResult.Error {
+
+    /**
+     * Redirect the browser back to the post-logout URI.
+     *
+     * @param redirectUri post-logout redirect target; non-null
+     * @param params      params to attach; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Redirect(URI redirectUri, Map<String, String> params) implements EndSessionResult {
+        public Redirect {
+            Objects.requireNonNull(redirectUri, "redirectUri");
+            params = Map.copyOf(Objects.requireNonNull(params, "params"));
+        }
+    }
+
+    /** Logout completed; no redirect. The adapter should render a confirmation page. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Done() implements EndSessionResult {}
+
+    /**
+     * Error response.
+     *
+     * @param code        wire error code; non-null
+     * @param description optional description; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Error(String code, String description) implements EndSessionResult {
+        public Error { Objects.requireNonNull(code, "code"); }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/IntrospectionRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/IntrospectionRequest.java
@@ -1,0 +1,24 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * RFC 7662 token introspection request.
+ *
+ * @param token         the token under inspection; non-null and non-blank
+ * @param tokenTypeHint optional hint ({@code "access_token"}, {@code "refresh_token"}); nullable
+ * @param clientId      authenticated calling client id; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record IntrospectionRequest(String token, String tokenTypeHint, String clientId) {
+
+    public IntrospectionRequest {
+        Objects.requireNonNull(token, "token");
+        if (token.isBlank()) {
+            throw new IllegalArgumentException("token must not be blank");
+        }
+        Objects.requireNonNull(clientId, "clientId");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/IntrospectionResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/IntrospectionResult.java
@@ -1,0 +1,42 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Outcome of {@code IdentityEngine.introspect} (RFC 7662). */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface IntrospectionResult permits IntrospectionResult.Active, IntrospectionResult.Inactive {
+
+    /**
+     * The token is active. RFC 7662 §2.2 — full claim set returned.
+     *
+     * @param subjectId        subject of the token
+     * @param clientId         client the token was issued to
+     * @param scope            granted scopes
+     * @param exp              expiration time
+     * @param iat              issued-at time
+     * @param additionalClaims any additional claims to surface; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Active(String subjectId,
+                  String clientId,
+                  Set<String> scope,
+                  Instant exp,
+                  Instant iat,
+                  Map<String, Object> additionalClaims) implements IntrospectionResult {
+        public Active {
+            Objects.requireNonNull(subjectId, "subjectId");
+            Objects.requireNonNull(clientId, "clientId");
+            scope = Set.copyOf(Objects.requireNonNull(scope, "scope"));
+            additionalClaims = Map.copyOf(Objects.requireNonNull(additionalClaims, "additionalClaims"));
+        }
+    }
+
+    /** Per RFC 7662, an inactive token is reported as {@code active: false} only. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Inactive() implements IntrospectionResult {}
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/JsonWebKey.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/JsonWebKey.java
@@ -1,0 +1,35 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An RFC 7517 JSON Web Key, as a typed wrapper around the wire-format
+ * key/value map. Mandatory fields ({@code kty}, {@code kid}) are typed;
+ * the rest live in {@code additionalParameters}.
+ *
+ * <p>The engine never serializes/deserializes JWKs itself — that lives
+ * in {@code tokido-core-identity-jwt} (M2).
+ *
+ * @param kty                  RFC 7517 §4.1 — key type ({@code "RSA"}, {@code "EC"}, etc.); non-null
+ * @param kid                  RFC 7517 §4.5 — key id; non-null and non-blank
+ * @param use                  RFC 7517 §4.2 — public key use ({@code "sig"}, {@code "enc"}); nullable
+ * @param alg                  RFC 7517 §4.4 — intended algorithm; nullable
+ * @param additionalParameters all other JWK fields (n, e, x, y, crv, ...); non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record JsonWebKey(String kty, String kid, String use, String alg,
+                         Map<String, Object> additionalParameters) {
+
+    public JsonWebKey {
+        Objects.requireNonNull(kty, "kty");
+        Objects.requireNonNull(kid, "kid");
+        if (kid.isBlank()) {
+            throw new IllegalArgumentException("kid must not be blank");
+        }
+        additionalParameters = Map.copyOf(
+                Objects.requireNonNull(additionalParameters, "additionalParameters"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/JsonWebKeySet.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/JsonWebKeySet.java
@@ -1,0 +1,19 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * RFC 7517 §5 — a JWK Set, returned by the engine's JWKS endpoint.
+ *
+ * @param keys the keys in the set; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record JsonWebKeySet(Set<JsonWebKey> keys) {
+
+    public JsonWebKeySet {
+        keys = Set.copyOf(Objects.requireNonNull(keys, "keys"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/RevocationRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/RevocationRequest.java
@@ -1,0 +1,24 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * RFC 7009 token revocation request.
+ *
+ * @param token         the token to revoke; non-null and non-blank
+ * @param tokenTypeHint optional hint ({@code "access_token"}, {@code "refresh_token"}); nullable
+ * @param clientId      authenticated calling client id; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record RevocationRequest(String token, String tokenTypeHint, String clientId) {
+
+    public RevocationRequest {
+        Objects.requireNonNull(token, "token");
+        if (token.isBlank()) {
+            throw new IllegalArgumentException("token must not be blank");
+        }
+        Objects.requireNonNull(clientId, "clientId");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/RevocationResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/RevocationResult.java
@@ -1,0 +1,25 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/** Outcome of {@code IdentityEngine.revoke} (RFC 7009). */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface RevocationResult permits RevocationResult.Revoked, RevocationResult.Error {
+
+    /** Per RFC 7009 §2.2, a successful revocation always responds 200 — even for unknown tokens. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Revoked() implements RevocationResult {}
+
+    /**
+     * Error response.
+     *
+     * @param code        wire error code; non-null
+     * @param description optional description; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Error(String code, String description) implements RevocationResult {
+        public Error { Objects.requireNonNull(code, "code"); }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/TokenRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/TokenRequest.java
@@ -1,0 +1,50 @@
+package io.tokido.core.identity.protocol;
+
+import io.tokido.core.identity.spi.ClientAuthenticationMethod;
+import org.apiguardian.api.API;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * OAuth 2.0 / OIDC token endpoint request (RFC 6749 §3.2 / OIDC Core §3.1.3).
+ *
+ * @param grantType    grant type wire string (e.g., {@code "authorization_code"}); non-null and non-blank
+ * @param clientId     client id; non-null and non-blank
+ * @param clientSecret submitted client secret (for client_secret_post / client_secret_basic); nullable
+ * @param authMethod   how the client authenticated; non-null
+ * @param code         authorization code (for authorization_code grant); nullable
+ * @param redirectUri  redirect_uri (must match the authorize request); nullable
+ * @param codeVerifier PKCE code_verifier; nullable
+ * @param refreshToken refresh token (for refresh_token grant); nullable
+ * @param scopes       requested scopes (for refresh / client_credentials); null becomes empty
+ * @param additional   additional adapter-supplied parameters; null becomes empty map
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record TokenRequest(
+        String grantType,
+        String clientId,
+        String clientSecret,
+        ClientAuthenticationMethod authMethod,
+        String code,
+        String redirectUri,
+        String codeVerifier,
+        String refreshToken,
+        Set<String> scopes,
+        Map<String, String> additional) {
+
+    public TokenRequest {
+        Objects.requireNonNull(grantType, "grantType");
+        if (grantType.isBlank()) {
+            throw new IllegalArgumentException("grantType must not be blank");
+        }
+        Objects.requireNonNull(clientId, "clientId");
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId must not be blank");
+        }
+        Objects.requireNonNull(authMethod, "authMethod");
+        scopes = scopes == null ? Set.of() : Set.copyOf(scopes);
+        additional = additional == null ? Map.of() : Map.copyOf(additional);
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/TokenResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/TokenResult.java
@@ -1,0 +1,53 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+
+/** Outcome of {@code IdentityEngine.token}. */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface TokenResult permits TokenResult.Success, TokenResult.Error {
+
+    /**
+     * Successful token response (RFC 6749 §5.1 / OIDC Core §3.1.3.3).
+     *
+     * @param accessToken  issued access token; non-null
+     * @param tokenType    token type ({@code "Bearer"}); non-null
+     * @param expiresIn    access-token lifetime; non-null
+     * @param refreshToken issued refresh token; nullable (not issued for client_credentials)
+     * @param idToken      issued ID token; nullable (not issued without {@code openid} scope)
+     * @param scope        granted scopes; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Success(String accessToken,
+                   String tokenType,
+                   Duration expiresIn,
+                   String refreshToken,
+                   String idToken,
+                   Set<String> scope) implements TokenResult {
+        public Success {
+            Objects.requireNonNull(accessToken, "accessToken");
+            Objects.requireNonNull(tokenType, "tokenType");
+            Objects.requireNonNull(expiresIn, "expiresIn");
+            scope = Set.copyOf(Objects.requireNonNull(scope, "scope"));
+        }
+    }
+
+    /**
+     * Error response (RFC 6749 §5.2).
+     *
+     * @param code        wire error code; non-null and non-blank
+     * @param description optional human-readable description; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Error(String code, String description) implements TokenResult {
+        public Error {
+            Objects.requireNonNull(code, "code");
+            if (code.isBlank()) {
+                throw new IllegalArgumentException("code must not be blank");
+            }
+        }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/UserInfoRequest.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/UserInfoRequest.java
@@ -1,0 +1,24 @@
+package io.tokido.core.identity.protocol;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * UserInfo endpoint request (OIDC Core §5.3). Carries the bearer access
+ * token submitted in the {@code Authorization} header or as a form
+ * parameter; framework adapters parse the HTTP request and pass the token
+ * here.
+ *
+ * @param accessToken the access token; non-null and non-blank
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record UserInfoRequest(String accessToken) {
+
+    public UserInfoRequest {
+        Objects.requireNonNull(accessToken, "accessToken");
+        if (accessToken.isBlank()) {
+            throw new IllegalArgumentException("accessToken must not be blank");
+        }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/UserInfoResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/protocol/UserInfoResult.java
@@ -1,0 +1,37 @@
+package io.tokido.core.identity.protocol;
+
+import io.tokido.core.identity.spi.UserClaim;
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+import java.util.Set;
+
+/** Outcome of {@code IdentityEngine.userInfo}. */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface UserInfoResult permits UserInfoResult.Success, UserInfoResult.Error {
+
+    /**
+     * Successful userinfo response (OIDC Core §5.3.2).
+     *
+     * @param subjectId the {@code sub} claim; non-null
+     * @param claims    claims emitted; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Success(String subjectId, Set<UserClaim> claims) implements UserInfoResult {
+        public Success {
+            Objects.requireNonNull(subjectId, "subjectId");
+            claims = Set.copyOf(Objects.requireNonNull(claims, "claims"));
+        }
+    }
+
+    /**
+     * Error response.
+     *
+     * @param code        wire error code; non-null
+     * @param description optional human-readable description; nullable
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Error(String code, String description) implements UserInfoResult {
+        public Error { Objects.requireNonNull(code, "code"); }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/AuthenticationResult.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/AuthenticationResult.java
@@ -1,0 +1,39 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Outcome of a {@link UserStore#authenticate(String, String)} call.
+ * Implementations must return one of the four permitted variants.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public sealed interface AuthenticationResult
+        permits AuthenticationResult.Success,
+                AuthenticationResult.InvalidCredentials,
+                AuthenticationResult.AccountLocked,
+                AuthenticationResult.AccountDisabled {
+
+    /**
+     * Authentication succeeded; the returned user is the authenticated account.
+     *
+     * @param user the authenticated user; non-null
+     */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record Success(User user) implements AuthenticationResult {
+        public Success {
+            java.util.Objects.requireNonNull(user, "user");
+        }
+    }
+
+    /** Username or password did not match any known account. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record InvalidCredentials() implements AuthenticationResult {}
+
+    /** Account exists but is temporarily locked (e.g., too many failed attempts). */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record AccountLocked() implements AuthenticationResult {}
+
+    /** Account exists but is administratively disabled. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    record AccountDisabled() implements AuthenticationResult {}
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/BrokeredAuthentication.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/BrokeredAuthentication.java
@@ -1,0 +1,33 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Outcome of a federated authentication via {@code tokido-core-identity-broker}.
+ * Passed to {@link UserStore#createFromExternalProvider(BrokeredAuthentication)}
+ * so the local {@link User} record can be created or linked.
+ *
+ * @param providerId      the {@code providerId} from the {@code IdentityProvider} (M3)
+ * @param externalSubject the {@code sub} claim from the external IdP
+ * @param claims          additional claims received from the IdP
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record BrokeredAuthentication(String providerId,
+                                     String externalSubject,
+                                     Map<String, Object> claims) {
+
+    public BrokeredAuthentication {
+        Objects.requireNonNull(providerId, "providerId");
+        if (providerId.isBlank()) {
+            throw new IllegalArgumentException("providerId must not be blank");
+        }
+        Objects.requireNonNull(externalSubject, "externalSubject");
+        if (externalSubject.isBlank()) {
+            throw new IllegalArgumentException("externalSubject must not be blank");
+        }
+        claims = Map.copyOf(Objects.requireNonNull(claims, "claims"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/Client.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/Client.java
@@ -1,0 +1,68 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An OAuth/OIDC client registration.
+ *
+ * <p>All collection-valued fields are defensively copied to immutable form
+ * inside the canonical constructor. Implementations of {@link ClientStore}
+ * are not required to preserve insertion order of any set.
+ *
+ * @param clientId                 unique client identifier; non-null and non-blank
+ * @param secrets                  hashed client secrets (any may match); non-null, possibly empty for public clients
+ * @param redirectUris             registered redirect URIs (exact match)
+ * @param postLogoutRedirectUris   registered post-logout redirect URIs
+ * @param allowedScopes            scopes this client may request
+ * @param allowedGrantTypes        grant types this client may use
+ * @param tokenEndpointAuthMethods permitted client-authn methods at the token endpoint
+ * @param requirePkce              if true, authorize requests without PKCE are rejected
+ * @param allowOfflineAccess       if true, "offline_access" scope is granted on consent
+ * @param accessTokenLifetime      lifetime of access tokens issued to this client
+ * @param refreshTokenLifetime     lifetime of refresh tokens issued to this client
+ * @param refreshTokenUsage        {@link RefreshTokenUsage#ONE_TIME} or {@link RefreshTokenUsage#REUSE}
+ * @param claims                   additional client metadata (read-only key/value)
+ * @param enabled                  if false, all flows for this client are rejected
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record Client(
+        String clientId,
+        Set<ClientSecret> secrets,
+        Set<String> redirectUris,
+        Set<String> postLogoutRedirectUris,
+        Set<String> allowedScopes,
+        Set<GrantType> allowedGrantTypes,
+        Set<ClientAuthenticationMethod> tokenEndpointAuthMethods,
+        boolean requirePkce,
+        boolean allowOfflineAccess,
+        Duration accessTokenLifetime,
+        Duration refreshTokenLifetime,
+        RefreshTokenUsage refreshTokenUsage,
+        Map<String, String> claims,
+        boolean enabled) {
+
+    public Client {
+        Objects.requireNonNull(clientId, "clientId");
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId must not be blank");
+        }
+        secrets = Set.copyOf(Objects.requireNonNull(secrets, "secrets"));
+        redirectUris = Set.copyOf(Objects.requireNonNull(redirectUris, "redirectUris"));
+        postLogoutRedirectUris =
+                Set.copyOf(Objects.requireNonNull(postLogoutRedirectUris, "postLogoutRedirectUris"));
+        allowedScopes = Set.copyOf(Objects.requireNonNull(allowedScopes, "allowedScopes"));
+        allowedGrantTypes =
+                Set.copyOf(Objects.requireNonNull(allowedGrantTypes, "allowedGrantTypes"));
+        tokenEndpointAuthMethods =
+                Set.copyOf(Objects.requireNonNull(tokenEndpointAuthMethods, "tokenEndpointAuthMethods"));
+        Objects.requireNonNull(accessTokenLifetime, "accessTokenLifetime");
+        Objects.requireNonNull(refreshTokenLifetime, "refreshTokenLifetime");
+        Objects.requireNonNull(refreshTokenUsage, "refreshTokenUsage");
+        claims = Map.copyOf(Objects.requireNonNull(claims, "claims"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientAuthenticationMethod.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientAuthenticationMethod.java
@@ -1,0 +1,22 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Supported client authentication methods at the token endpoint, per
+ * OIDC Core §9 and RFC 6749 §2.3. The wire-protocol value is the
+ * lowercase form of the enum name (e.g., {@code CLIENT_SECRET_BASIC}
+ * → {@code "client_secret_basic"}).
+ *
+ * <p>Note: mTLS ({@code tls_client_auth}) and private-key JWT
+ * ({@code private_key_jwt}) are deferred to 0.2 per project-A doc §11.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public enum ClientAuthenticationMethod {
+    /** RFC 6749 §2.3.1 — HTTP Basic auth with client_id/client_secret. */
+    CLIENT_SECRET_BASIC,
+    /** RFC 6749 §2.3.1 — client_id/client_secret in the request body. */
+    CLIENT_SECRET_POST,
+    /** OIDC Core §9 — public client; no client authentication. */
+    NONE
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientSecret.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientSecret.java
@@ -1,0 +1,24 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A hashed client secret. The {@code value} is implementation-defined
+ * (e.g., bcrypt-encoded) — the engine treats it as opaque and only the
+ * {@link io.tokido.core.identity.engine.IdentityEngine} compares submitted
+ * credentials by delegating to a hashing strategy.
+ *
+ * @param value       opaque hashed secret; non-null
+ * @param description optional human-readable description; nullable
+ * @param expiration  optional expiration; null means "never expires"
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record ClientSecret(String value, String description, Instant expiration) {
+
+    public ClientSecret {
+        Objects.requireNonNull(value, "value");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ClientStore.java
@@ -1,0 +1,33 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Source of OAuth/OIDC client registrations. Read-only at the engine
+ * surface; implementations may persist clients however they wish.
+ *
+ * <p>Thread-safety: implementations must be safe for concurrent reads.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface ClientStore {
+
+    /**
+     * Look up a client by ID.
+     *
+     * @param clientId the client identifier
+     * @return the client, or {@code null} if no client is registered with this ID.
+     *         The {@code null} contract matches the existing tokido-core
+     *         {@code SecretStore.load} convention; consumers are responsible
+     *         for {@code null} checking.
+     */
+    Client findById(String clientId);
+
+    /**
+     * Quick existence probe; equivalent to {@code findById(clientId) != null}
+     * but may be faster for stores that index by id.
+     *
+     * @param clientId the client identifier
+     * @return true if a client is registered with this ID
+     */
+    boolean exists(String clientId);
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/Consent.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/Consent.java
@@ -1,0 +1,35 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A user's consent grant for a (subjectId, clientId, scopes) tuple.
+ * Consents are typically created when the user clicks "allow" on the
+ * consent screen and are looked up on subsequent authorize calls so the
+ * user is not re-prompted.
+ *
+ * @param subjectId  subject of the consent; non-null and non-blank
+ * @param clientId   client the consent applies to; non-null and non-blank
+ * @param scopes     scopes consented to
+ * @param expiration when the consent expires
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record Consent(String subjectId, String clientId, Set<String> scopes, Instant expiration) {
+
+    public Consent {
+        Objects.requireNonNull(subjectId, "subjectId");
+        if (subjectId.isBlank()) {
+            throw new IllegalArgumentException("subjectId must not be blank");
+        }
+        Objects.requireNonNull(clientId, "clientId");
+        if (clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId must not be blank");
+        }
+        scopes = Set.copyOf(Objects.requireNonNull(scopes, "scopes"));
+        Objects.requireNonNull(expiration, "expiration");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ConsentStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ConsentStore.java
@@ -1,0 +1,38 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Stores user consents per (subject, client) tuple. Looked up on every
+ * authorize call to skip the consent screen for previously-consented scopes.
+ *
+ * <p>Thread-safety: implementations must be safe for concurrent reads;
+ * {@link #store} and {@link #remove} must be atomic per-key.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface ConsentStore {
+
+    /**
+     * Look up an existing consent.
+     *
+     * @param subjectId subject
+     * @param clientId  client
+     * @return the consent, or {@code null} if no prior consent exists
+     */
+    Consent find(String subjectId, String clientId);
+
+    /**
+     * Persist a consent. Replaces any prior consent for the same (subject, client).
+     *
+     * @param consent the consent to store
+     */
+    void store(Consent consent);
+
+    /**
+     * Remove a consent. No-op if no consent exists.
+     *
+     * @param subjectId subject
+     * @param clientId  client
+     */
+    void remove(String subjectId, String clientId);
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/GrantType.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/GrantType.java
@@ -1,0 +1,18 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * OAuth 2.0 / OIDC grant types supported by the engine. The wire-protocol
+ * value (per RFC 6749 §1.3 and OIDC Core §3) is the lowercase, hyphenated
+ * form of the enum name (e.g., {@code AUTHORIZATION_CODE} → {@code "authorization_code"}).
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public enum GrantType {
+    /** OIDC Core §3.1, RFC 6749 §4.1 — the authorization code grant. */
+    AUTHORIZATION_CODE,
+    /** RFC 6749 §6 — the refresh token grant. */
+    REFRESH_TOKEN,
+    /** RFC 6749 §4.4 — the client credentials grant. */
+    CLIENT_CREDENTIALS
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/IdentityScope.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/IdentityScope.java
@@ -1,0 +1,30 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An OIDC identity scope (e.g., {@code openid}, {@code profile}, {@code email}).
+ * Identity scopes drive the claims emitted in the ID token and at the UserInfo
+ * endpoint.
+ *
+ * <p>Renamed from Duende's {@code IdentityResource} per ADR-0001 to avoid
+ * licensing/copyright entanglement with the Duende product family.
+ *
+ * @param name           wire-protocol scope name; non-null, non-blank
+ * @param displayName    optional display name for consent UIs; nullable
+ * @param userClaimNames claim names this scope unlocks in the ID token / userinfo
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record IdentityScope(String name, String displayName, Set<String> userClaimNames) {
+
+    public IdentityScope {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        userClaimNames = Set.copyOf(Objects.requireNonNull(userClaimNames, "userClaimNames"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/PersistedGrant.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/PersistedGrant.java
@@ -1,0 +1,55 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A server-side persisted artifact backing one of the OAuth/OIDC token-like
+ * objects: authorization codes, refresh tokens, opaque reference access tokens,
+ * and stored consents.
+ *
+ * <p>The {@code handle} is the opaque server-side identifier; the
+ * implementation maps it to retrieve the grant. The {@code data} field is
+ * an opaque serialized payload — the engine writes a self-describing string
+ * (typically JSON), the store treats it as an opaque blob.
+ *
+ * @param handle       opaque server-side identifier; non-null and non-blank
+ * @param type         grant type
+ * @param subjectId    subject this grant belongs to
+ * @param clientId     client this grant was issued to
+ * @param scopes       scopes granted
+ * @param creationTime when the grant was created
+ * @param expiration   when the grant expires
+ * @param consumedTime when the grant was consumed (one-time-use); {@code null} if not yet consumed
+ * @param data         opaque serialized payload; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record PersistedGrant(
+        String handle,
+        GrantType type,
+        String subjectId,
+        String clientId,
+        Set<String> scopes,
+        Instant creationTime,
+        Instant expiration,
+        Instant consumedTime,
+        String data) {
+
+    public PersistedGrant {
+        Objects.requireNonNull(handle, "handle");
+        if (handle.isBlank()) {
+            throw new IllegalArgumentException("handle must not be blank");
+        }
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(subjectId, "subjectId");
+        Objects.requireNonNull(clientId, "clientId");
+        scopes = Set.copyOf(Objects.requireNonNull(scopes, "scopes"));
+        Objects.requireNonNull(creationTime, "creationTime");
+        Objects.requireNonNull(expiration, "expiration");
+        // consumedTime is intentionally nullable
+        Objects.requireNonNull(data, "data");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ProtectedResource.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ProtectedResource.java
@@ -1,0 +1,28 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An API/protected resource — the audience of access tokens granted scopes
+ * defined by this resource.
+ *
+ * <p>Renamed from Duende's {@code ApiResource} per ADR-0001.
+ *
+ * @param name        unique resource name (used as access-token audience)
+ * @param displayName optional display name for consent UIs
+ * @param scopes      the scopes this resource publishes
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record ProtectedResource(String name, String displayName, Set<ResourceScope> scopes) {
+
+    public ProtectedResource {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        scopes = Set.copyOf(Objects.requireNonNull(scopes, "scopes"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/RefreshTokenUsage.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/RefreshTokenUsage.java
@@ -1,0 +1,18 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Refresh-token rotation policy per client. {@code ONE_TIME} (default)
+ * means each refresh consumes the prior refresh token and issues a new
+ * one; {@code REUSE} permits the same refresh token to be used until
+ * its lifetime expires. ADR-0008 (M2) covers the rotation mechanics
+ * and theft-detection rules.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public enum RefreshTokenUsage {
+    /** Each refresh consumes the prior refresh token; a new one is issued. */
+    ONE_TIME,
+    /** The same refresh token may be used until expiration. */
+    REUSE
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ResourceScope.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ResourceScope.java
@@ -1,0 +1,25 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * A scope offered by a {@link ProtectedResource}. The wire-protocol scope name
+ * is the {@code name} field; consent UIs may use {@code displayName}.
+ *
+ * <p>Renamed from Duende's {@code ApiScope} per ADR-0001.
+ *
+ * @param name        wire-protocol scope name; non-null, non-blank
+ * @param displayName optional display name; nullable
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record ResourceScope(String name, String displayName) {
+
+    public ResourceScope {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ResourceStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/ResourceStore.java
@@ -1,0 +1,52 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Set;
+
+/**
+ * Source of identity scopes and protected resources.
+ *
+ * <p>The engine consults this SPI during scope resolution: it filters
+ * the {@code scope} parameter on authorize/token requests, and produces the
+ * audience/scope claims on issued access tokens.
+ *
+ * <p>Thread-safety: implementations must be safe for concurrent reads.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface ResourceStore {
+
+    /**
+     * Look up an identity scope by name.
+     *
+     * @param name scope name
+     * @return the scope, or {@code null} if not found
+     */
+    IdentityScope findIdentityScope(String name);
+
+    /**
+     * Look up a protected resource by name.
+     *
+     * @param name resource name (used as access-token audience)
+     * @return the resource, or {@code null} if not found
+     */
+    ProtectedResource findProtectedResource(String name);
+
+    /**
+     * All identity scopes whose names appear in {@code names}.
+     * Names absent from the store are silently dropped from the result.
+     *
+     * @param names scope names to look up
+     * @return non-null, possibly empty, immutable set
+     */
+    Set<IdentityScope> findIdentityScopesByName(Set<String> names);
+
+    /**
+     * All protected resources whose published scopes intersect {@code scopeNames}.
+     * Returns the resources, not the scope subset.
+     *
+     * @param scopeNames scope names to test against
+     * @return non-null, possibly empty, immutable set
+     */
+    Set<ProtectedResource> findResourcesByScope(Set<String> scopeNames);
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/TokenStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/TokenStore.java
@@ -1,0 +1,58 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+/**
+ * Persisted-grant store. Backs authorization codes, refresh tokens, reference
+ * tokens, and consent grants. Named {@code TokenStore} per ADR-0001 (Duende
+ * calls it {@code PersistedGrantStore} but {@code TokenStore} is more
+ * discoverable to Java developers).
+ *
+ * <p>Thread-safety: {@link #findByHandle} must be safe for concurrent reads.
+ * {@link #store}, {@link #remove}, and the bulk-remove methods must be
+ * atomic per-handle.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface TokenStore {
+
+    /**
+     * Persist a grant. If a grant with the same handle exists, behavior is
+     * implementation-defined (typically replace).
+     *
+     * @param grant the grant to persist
+     */
+    void store(PersistedGrant grant);
+
+    /**
+     * Look up by handle.
+     *
+     * @param handle the grant's opaque server-side identifier
+     * @return the grant, or {@code null} for unknown handles AND for expired
+     *         grants (implementations are responsible for the expiration check)
+     */
+    PersistedGrant findByHandle(String handle);
+
+    /**
+     * Remove a single grant by handle. No-op if the handle is unknown.
+     *
+     * @param handle the grant's identifier
+     */
+    void remove(String handle);
+
+    /**
+     * Remove every grant for the given (subjectId, clientId).
+     *
+     * @param subjectId subject
+     * @param clientId  client
+     */
+    void removeAll(String subjectId, String clientId);
+
+    /**
+     * Remove every grant for the given (subjectId, clientId) of the given type.
+     *
+     * @param subjectId subject
+     * @param clientId  client
+     * @param type      grant type filter
+     */
+    void removeAll(String subjectId, String clientId, GrantType type);
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/User.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/User.java
@@ -1,0 +1,29 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A user account known to the OIDC engine.
+ *
+ * @param subjectId immutable identifier (the {@code sub} claim); non-null and non-blank
+ * @param username  human-readable username (login name); non-null
+ * @param enabled   if false, all flows for this user are rejected
+ * @param profile   additional profile attributes (read-only key/value);
+ *                  separate from {@link UserClaim} which is the wire-format
+ *                  emitted in tokens
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record User(String subjectId, String username, boolean enabled, Map<String, Object> profile) {
+
+    public User {
+        Objects.requireNonNull(subjectId, "subjectId");
+        if (subjectId.isBlank()) {
+            throw new IllegalArgumentException("subjectId must not be blank");
+        }
+        Objects.requireNonNull(username, "username");
+        profile = Map.copyOf(Objects.requireNonNull(profile, "profile"));
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/UserClaim.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/UserClaim.java
@@ -1,0 +1,26 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Objects;
+
+/**
+ * A single user claim — a {@code (type, value)} pair as emitted in the
+ * ID token or at the UserInfo endpoint. The {@code type} is the standard
+ * OIDC claim name (e.g., {@code "name"}, {@code "email"}); the {@code value}
+ * is the JSON-serialized value as a string.
+ *
+ * @param type  claim name; non-null and non-blank
+ * @param value claim value as a JSON-serializable string; non-null
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public record UserClaim(String type, String value) {
+
+    public UserClaim {
+        Objects.requireNonNull(type, "type");
+        if (type.isBlank()) {
+            throw new IllegalArgumentException("type must not be blank");
+        }
+        Objects.requireNonNull(value, "value");
+    }
+}

--- a/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/UserStore.java
+++ b/tokido-core-identity-api/src/main/java/io/tokido/core/identity/spi/UserStore.java
@@ -1,0 +1,72 @@
+package io.tokido.core.identity.spi;
+
+import org.apiguardian.api.API;
+
+import java.util.Set;
+
+/**
+ * Source of user accounts and the local-credential authenticator.
+ *
+ * <p>Most methods are read-only. {@link #createFromExternalProvider} is the
+ * single mutation: it materializes a local {@link User} the first time a
+ * federated identity completes broker callback at M3.
+ *
+ * <p>Thread-safety: implementations must be safe for concurrent reads;
+ * the create operation must be atomic per-{@code (providerId, externalSubject)}.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface UserStore {
+
+    /**
+     * Look up by subject id.
+     *
+     * @param subjectId the subject identifier
+     * @return the user, or {@code null} if not found
+     */
+    User findById(String subjectId);
+
+    /**
+     * Look up by username.
+     *
+     * @param username the login username
+     * @return the user, or {@code null} if not found
+     */
+    User findByUsername(String username);
+
+    /**
+     * Authenticate a user with a username and a credential. Implementations
+     * are responsible for hashing/verifying the credential.
+     *
+     * @param username   the login username
+     * @param credential the submitted credential (typically a password)
+     * @return one of the four {@link AuthenticationResult} variants
+     */
+    AuthenticationResult authenticate(String username, String credential);
+
+    /**
+     * Look up an existing federated mapping.
+     *
+     * @param providerId      the IdP's provider id
+     * @param externalSubject the {@code sub} claim from the external IdP
+     * @return the linked user, or {@code null} if no link exists
+     */
+    User findByExternalProvider(String providerId, String externalSubject);
+
+    /**
+     * Create or fetch the local {@link User} for a federated identity.
+     * Idempotent: calling twice with the same {@code BrokeredAuthentication}
+     * returns the same {@link User}.
+     *
+     * @param brokered the broker callback result
+     * @return the local user (newly created or existing)
+     */
+    User createFromExternalProvider(BrokeredAuthentication brokered);
+
+    /**
+     * All claims emitted for this subject in tokens.
+     *
+     * @param subjectId the subject identifier
+     * @return non-null, possibly empty, immutable set
+     */
+    Set<UserClaim> claims(String subjectId);
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/NoFrameworkImportsTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/NoFrameworkImportsTest.java
@@ -1,0 +1,32 @@
+package io.tokido.core.identity;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture gate: no class in {@code tokido-core-identity-api} may import
+ * Spring, Quarkus, Jakarta, Servlet, or JAX-RS types. The OIDC extension
+ * is framework-agnostic by ADR-0003.
+ */
+class NoFrameworkImportsTest {
+
+    @Test
+    void noFrameworkImports() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "io.quarkus..",
+                        "jakarta..",
+                        "javax.servlet..",
+                        "jakarta.ws.rs..")
+                .because("identity modules must remain framework-agnostic (ADR-0003)");
+
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.tokido.core.identity"));
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/key/AbstractKeyStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/key/AbstractKeyStoreContract.java
@@ -1,0 +1,79 @@
+package io.tokido.core.identity.key;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests for any {@link KeyStore} implementation. Subclasses provide
+ * a {@link #createStore(Set)} factory that returns a {@link KeyStore} pre-seeded
+ * with the given keys. Every concrete implementation in tokido-core-test (M2)
+ * and downstream (Project B JPA, Project C DynamoDB) extends this class.
+ *
+ * <p>The contract is the public source of truth for what a {@link KeyStore}
+ * must do; if a behavior should be required, it has a test here.
+ */
+public abstract class AbstractKeyStoreContract {
+
+    /** Subclass-provided factory returning a store seeded with {@code keys}. */
+    protected abstract KeyStore createStore(Set<SigningKey> keys);
+
+    private SigningKey sampleActive(String kid, SignatureAlgorithm alg) {
+        return new SigningKey(
+                kid, alg,
+                new KeyMaterial(new byte[]{1, 2, 3}, alg),
+                KeyState.ACTIVE,
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-08-01T00:00:00Z"));
+    }
+
+    private SigningKey sampleRetired(String kid, SignatureAlgorithm alg) {
+        return new SigningKey(
+                kid, alg,
+                new KeyMaterial(new byte[]{4, 5, 6}, alg),
+                KeyState.RETIRED,
+                Instant.parse("2026-02-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:00:00Z"));
+    }
+
+    @Test
+    void activeSigningKeyReturnsTheActiveKeyForAlgorithm() {
+        SigningKey active = sampleActive("kid-active", SignatureAlgorithm.RS256);
+        SigningKey retired = sampleRetired("kid-retired", SignatureAlgorithm.RS256);
+        KeyStore store = createStore(Set.of(active, retired));
+
+        assertThat(store.activeSigningKey(SignatureAlgorithm.RS256)).isEqualTo(active);
+    }
+
+    @Test
+    void activeSigningKeyThrowsWhenNoActiveKeyForAlgorithm() {
+        SigningKey rsActive = sampleActive("kid-rs", SignatureAlgorithm.RS256);
+        KeyStore store = createStore(Set.of(rsActive));
+
+        assertThatThrownBy(() -> store.activeSigningKey(SignatureAlgorithm.ES256))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void allKeysReturnsActiveAndRetired() {
+        SigningKey active = sampleActive("kid-active", SignatureAlgorithm.RS256);
+        SigningKey retired = sampleRetired("kid-retired", SignatureAlgorithm.RS256);
+        KeyStore store = createStore(Set.of(active, retired));
+
+        assertThat(store.allKeys()).containsExactlyInAnyOrder(active, retired);
+    }
+
+    @Test
+    void allKeysIsImmutable() {
+        SigningKey active = sampleActive("kid-active", SignatureAlgorithm.RS256);
+        KeyStore store = createStore(Set.of(active));
+
+        Set<SigningKey> snapshot = store.allKeys();
+        assertThatThrownBy(() -> snapshot.add(sampleActive("k2", SignatureAlgorithm.ES256)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/key/KeyStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/key/KeyStoreTypesTest.java
@@ -1,0 +1,98 @@
+package io.tokido.core.identity.key;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class KeyStoreTypesTest {
+
+    @Test
+    void keyMaterialAcceptsBytesAndAlg() {
+        KeyMaterial m = new KeyMaterial(new byte[]{1, 2, 3}, SignatureAlgorithm.RS256);
+        assertThat(m.bytes()).containsExactly(1, 2, 3);
+        assertThat(m.alg()).isEqualTo(SignatureAlgorithm.RS256);
+    }
+
+    @Test
+    void keyMaterialRejectsNullBytes() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new KeyMaterial(null, SignatureAlgorithm.RS256));
+    }
+
+    @Test
+    void keyMaterialRejectsNullAlg() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new KeyMaterial(new byte[]{1}, null));
+    }
+
+    @Test
+    void signingKeyExposesAllFields() {
+        Instant nbf = Instant.parse("2026-05-01T00:00:00Z");
+        Instant exp = Instant.parse("2026-08-01T00:00:00Z");
+        KeyMaterial mat = new KeyMaterial(new byte[]{42}, SignatureAlgorithm.RS256);
+        SigningKey k = new SigningKey("kid-1", SignatureAlgorithm.RS256, mat, KeyState.ACTIVE, nbf, exp);
+        assertThat(k.kid()).isEqualTo("kid-1");
+        assertThat(k.alg()).isEqualTo(SignatureAlgorithm.RS256);
+        assertThat(k.material()).isSameAs(mat);
+        assertThat(k.state()).isEqualTo(KeyState.ACTIVE);
+        assertThat(k.notBefore()).isEqualTo(nbf);
+        assertThat(k.notAfter()).isEqualTo(exp);
+    }
+
+    @Test
+    void signingKeyRejectsBlankKid() {
+        KeyMaterial mat = new KeyMaterial(new byte[]{42}, SignatureAlgorithm.RS256);
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new SigningKey("", SignatureAlgorithm.RS256, mat, KeyState.ACTIVE,
+                        Instant.now(), Instant.now().plusSeconds(60)));
+    }
+
+    @Test
+    void signingKeyRejectsAlgMismatch() {
+        KeyMaterial mat = new KeyMaterial(new byte[]{42}, SignatureAlgorithm.RS256);
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new SigningKey("kid", SignatureAlgorithm.ES256, mat, KeyState.ACTIVE,
+                        Instant.now(), Instant.now().plusSeconds(60)));
+    }
+
+    @Test
+    void signingKeyRejectsNotAfterBeforeNotBefore() {
+        KeyMaterial mat = new KeyMaterial(new byte[]{42}, SignatureAlgorithm.RS256);
+        Instant t = Instant.parse("2026-05-01T00:00:00Z");
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new SigningKey("kid", SignatureAlgorithm.RS256, mat, KeyState.ACTIVE, t, t));
+    }
+
+    /**
+     * Smoke runner that drives {@link AbstractKeyStoreContract} against a tiny
+     * Set-backed in-memory KeyStore. The "real" in-memory KeyStore lands in
+     * tokido-core-test at M2; this is just enough to exercise the contract for
+     * coverage.
+     */
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractKeyStoreContract {
+        @Override
+        protected KeyStore createStore(java.util.Set<SigningKey> keys) {
+            java.util.Set<SigningKey> snapshot = java.util.Set.copyOf(keys);
+            return new KeyStore() {
+                @Override
+                public SigningKey activeSigningKey(SignatureAlgorithm alg) {
+                    return snapshot.stream()
+                            .filter(k -> k.state() == KeyState.ACTIVE && k.alg() == alg)
+                            .findFirst()
+                            .orElseThrow(() ->
+                                    new IllegalStateException("no active key for " + alg));
+                }
+
+                @Override
+                public java.util.Set<SigningKey> allKeys() {
+                    return snapshot;
+                }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/DiscoveryAndJwksTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/DiscoveryAndJwksTest.java
@@ -1,0 +1,109 @@
+package io.tokido.core.identity.protocol;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class DiscoveryAndJwksTest {
+
+    @Test
+    void jsonWebKeyRejectsBlankKid() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new JsonWebKey("RSA", "", "sig", "RS256", Map.of()));
+    }
+
+    @Test
+    void jsonWebKeyRejectsNullKty() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new JsonWebKey(null, "kid-1", "sig", "RS256", Map.of()));
+    }
+
+    @Test
+    void jsonWebKeyAcceptsNullableUseAndAlg() {
+        JsonWebKey k = new JsonWebKey("RSA", "kid-1", null, null, Map.of());
+        assertThat(k.use()).isNull();
+        assertThat(k.alg()).isNull();
+    }
+
+    @Test
+    void jsonWebKeyCopiesAdditionalParametersToImmutable() {
+        JsonWebKey k = new JsonWebKey("RSA", "kid-1", "sig", "RS256",
+                Map.of("n", "modulus-bytes", "e", "AQAB"));
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> k.additionalParameters().put("k", "v"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void jsonWebKeySetCopiesKeysToImmutable() {
+        JsonWebKey k = new JsonWebKey("RSA", "kid-1", "sig", "RS256", Map.of());
+        JsonWebKeySet set = new JsonWebKeySet(Set.of(k));
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> set.keys().add(k))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void discoveryDocumentRequiresMandatoryEndpoints() {
+        assertThatNullPointerException().isThrownBy(() ->
+                new DiscoveryDocument(
+                        null,
+                        URI.create("https://i/auth"),
+                        URI.create("https://i/token"),
+                        null, URI.create("https://i/jwks"),
+                        null, null, null,
+                        Set.of("code"), Set.of("authorization_code"),
+                        Set.of("public"), Set.of("RS256"),
+                        Set.of("openid"), Set.of("client_secret_basic"),
+                        Set.of("sub"), Map.of()));
+    }
+
+    @Test
+    void discoveryDocumentNullableEndpointsAccepted() {
+        DiscoveryDocument doc = new DiscoveryDocument(
+                URI.create("https://issuer.example/"),
+                URI.create("https://issuer.example/auth"),
+                URI.create("https://issuer.example/token"),
+                null, // userinfoEndpoint nullable
+                URI.create("https://issuer.example/jwks"),
+                null, null, null, // introspection, revocation, end_session nullable
+                Set.of("code"),
+                Set.of("authorization_code"),
+                Set.of("public"),
+                Set.of("RS256"),
+                null, null, null, // optional collections
+                Map.of());
+        assertThat(doc.userinfoEndpoint()).isNull();
+        assertThat(doc.scopesSupported()).isEmpty();
+        assertThat(doc.tokenEndpointAuthMethodsSupported()).isEmpty();
+        assertThat(doc.claimsSupported()).isEmpty();
+    }
+
+    @Test
+    void discoveryDocumentCopiesCollectionsToImmutable() {
+        DiscoveryDocument doc = new DiscoveryDocument(
+                URI.create("https://issuer.example/"),
+                URI.create("https://issuer.example/auth"),
+                URI.create("https://issuer.example/token"),
+                URI.create("https://issuer.example/userinfo"),
+                URI.create("https://issuer.example/jwks"),
+                null, null, null,
+                Set.of("code"),
+                Set.of("authorization_code", "refresh_token"),
+                Set.of("public"),
+                Set.of("RS256", "ES256"),
+                Set.of("openid", "profile"),
+                Set.of("client_secret_basic"),
+                Set.of("sub", "name"),
+                Map.of("require_request_uri_registration", false));
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> doc.responseTypesSupported().add("token"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/RequestTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/RequestTypesTest.java
@@ -1,0 +1,84 @@
+package io.tokido.core.identity.protocol;
+
+import io.tokido.core.identity.spi.ClientAuthenticationMethod;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class RequestTypesTest {
+
+    @Test
+    void authorizeRequestRejectsNullClientId() {
+        assertThatNullPointerException().isThrownBy(() ->
+                new AuthorizeRequest(null, "code", "https://app/cb",
+                        Set.of("openid"), "state-1", null, null, null,
+                        null, Set.of(), null, null, null, null, Map.of()));
+    }
+
+    @Test
+    void authorizeRequestRejectsBlankClientId() {
+        assertThatIllegalArgumentException().isThrownBy(() ->
+                new AuthorizeRequest("", "code", "https://app/cb",
+                        Set.of("openid"), "state-1", null, null, null,
+                        null, Set.of(), null, null, null, null, Map.of()));
+    }
+
+    @Test
+    void authorizeRequestNullCollectionsBecomeEmpty() {
+        AuthorizeRequest r = new AuthorizeRequest("client-1", "code", null,
+                null, null, null, null, null, null, null, null, null, null, null, null);
+        assertThat(r.scopes()).isEmpty();
+        assertThat(r.acrValues()).isEmpty();
+        assertThat(r.additional()).isEmpty();
+    }
+
+    @Test
+    void tokenRequestExposesAllFields() {
+        TokenRequest req = new TokenRequest(
+                "authorization_code", "client-1", "secret",
+                ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                "code-1", "https://app/cb", "verifier-1",
+                null, Set.of("openid"), Map.of());
+        assertThat(req.grantType()).isEqualTo("authorization_code");
+        assertThat(req.clientId()).isEqualTo("client-1");
+        assertThat(req.code()).isEqualTo("code-1");
+    }
+
+    @Test
+    void tokenRequestRejectsBlankGrantType() {
+        assertThatIllegalArgumentException().isThrownBy(() ->
+                new TokenRequest("", "c", null, ClientAuthenticationMethod.NONE,
+                        null, null, null, null, Set.of(), Map.of()));
+    }
+
+    @Test
+    void userInfoRequestRejectsBlankAccessToken() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new UserInfoRequest(""));
+    }
+
+    @Test
+    void introspectionRequestRejectsBlankToken() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new IntrospectionRequest("", null, "client"));
+    }
+
+    @Test
+    void revocationRequestRejectsBlankToken() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new RevocationRequest("", null, "client"));
+    }
+
+    @Test
+    void endSessionRequestAcceptsAllNulls() {
+        EndSessionRequest r = new EndSessionRequest(null, null, null);
+        assertThat(r.idTokenHint()).isNull();
+        assertThat(r.postLogoutRedirectUri()).isNull();
+        assertThat(r.state()).isNull();
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/ResultTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/protocol/ResultTypesTest.java
@@ -1,0 +1,158 @@
+package io.tokido.core.identity.protocol;
+
+import io.tokido.core.identity.spi.UserClaim;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ResultTypesTest {
+
+    @Test
+    void authorizeResultRedirectCopiesParams() {
+        AuthorizeResult.Redirect r = new AuthorizeResult.Redirect(
+                URI.create("https://app/cb"),
+                Map.of("code", "abc"));
+        assertThat(r.params()).containsEntry("code", "abc");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> r.params().put("k", "v"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void authorizeResultErrorRequiresNonBlankCode() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new AuthorizeResult.Error("", "desc", "state"));
+    }
+
+    @Test
+    void authorizeResultMfaRequiredCopiesAcr() {
+        AuthorizeResult.MfaRequired m = new AuthorizeResult.MfaRequired(
+                Set.of("urn:tokido:acr:mfa"), "state-1");
+        assertThat(m.requiredAcr()).containsExactly("urn:tokido:acr:mfa");
+    }
+
+    @Test
+    void tokenResultSuccessRequiresAccessToken() {
+        assertThatNullPointerException().isThrownBy(() ->
+                new TokenResult.Success(null, "Bearer", Duration.ofSeconds(60),
+                        null, null, Set.of()));
+    }
+
+    @Test
+    void tokenResultErrorRequiresNonBlankCode() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new TokenResult.Error("", "desc"));
+    }
+
+    @Test
+    void userInfoResultSuccessExposesClaims() {
+        UserClaim email = new UserClaim("email", "alice@example.com");
+        UserInfoResult.Success s = new UserInfoResult.Success("sub-1", Set.of(email));
+        assertThat(s.claims()).containsExactly(email);
+    }
+
+    @Test
+    void introspectionResultActiveExposesScope() {
+        IntrospectionResult.Active a = new IntrospectionResult.Active(
+                "sub", "client", Set.of("openid"),
+                Instant.now().plusSeconds(60), Instant.now(), Map.of());
+        assertThat(a.scope()).containsExactly("openid");
+    }
+
+    @Test
+    void introspectionResultInactiveIsNoArg() {
+        assertThat(new IntrospectionResult.Inactive()).isNotNull();
+    }
+
+    @Test
+    void revocationResultRevokedIsNoArg() {
+        assertThat(new RevocationResult.Revoked()).isNotNull();
+    }
+
+    @Test
+    void endSessionResultDoneIsNoArg() {
+        assertThat(new EndSessionResult.Done()).isNotNull();
+    }
+
+    @Test
+    void authenticationStateAnonymousIsAllNullsAndEmpty() {
+        AuthenticationState a = AuthenticationState.anonymous();
+        assertThat(a.subjectId()).isNull();
+        assertThat(a.authenticatedAt()).isNull();
+        assertThat(a.amr()).isEmpty();
+        assertThat(a.acr()).isNull();
+        assertThat(a.session()).isEmpty();
+    }
+
+    @Test
+    void authenticationStateNullCollectionsBecomeEmpty() {
+        AuthenticationState a = new AuthenticationState("sub", Instant.now(), null, null, null);
+        assertThat(a.amr()).isEmpty();
+        assertThat(a.session()).isEmpty();
+    }
+
+    @Test
+    void authorizeResultLoginRequiredIsConstructable() {
+        AuthorizeResult.LoginRequired lr = new AuthorizeResult.LoginRequired("max_age");
+        assertThat(lr.reason()).isEqualTo("max_age");
+    }
+
+    @Test
+    void authorizeResultConsentRequiredCopiesScopes() {
+        AuthorizeResult.ConsentRequired cr = new AuthorizeResult.ConsentRequired(
+                Set.of("profile", "email"), "s1");
+        assertThat(cr.requestedScopes()).containsExactlyInAnyOrder("profile", "email");
+        assertThat(cr.state()).isEqualTo("s1");
+    }
+
+    @Test
+    void tokenResultSuccessExposesFields() {
+        TokenResult.Success s = new TokenResult.Success(
+                "at", "Bearer", Duration.ofSeconds(3600), "rt", "idt", Set.of("openid"));
+        assertThat(s.accessToken()).isEqualTo("at");
+        assertThat(s.tokenType()).isEqualTo("Bearer");
+        assertThat(s.expiresIn()).isEqualTo(Duration.ofSeconds(3600));
+        assertThat(s.refreshToken()).isEqualTo("rt");
+        assertThat(s.idToken()).isEqualTo("idt");
+        assertThat(s.scope()).containsExactly("openid");
+    }
+
+    @Test
+    void userInfoResultErrorRequiresCode() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new UserInfoResult.Error(null, "desc"));
+        UserInfoResult.Error e = new UserInfoResult.Error("invalid_token", null);
+        assertThat(e.code()).isEqualTo("invalid_token");
+    }
+
+    @Test
+    void revocationResultErrorRequiresCode() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new RevocationResult.Error(null, "desc"));
+        RevocationResult.Error e = new RevocationResult.Error("unsupported_token_type", null);
+        assertThat(e.code()).isEqualTo("unsupported_token_type");
+    }
+
+    @Test
+    void endSessionResultRedirectCopiesParams() {
+        EndSessionResult.Redirect r = new EndSessionResult.Redirect(
+                URI.create("https://app/logout"), Map.of("state", "xyz"));
+        assertThat(r.redirectUri()).isEqualTo(URI.create("https://app/logout"));
+        assertThat(r.params()).containsEntry("state", "xyz");
+    }
+
+    @Test
+    void endSessionResultErrorRequiresCode() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new EndSessionResult.Error(null, "desc"));
+        EndSessionResult.Error e = new EndSessionResult.Error("invalid_request", "bad");
+        assertThat(e.code()).isEqualTo("invalid_request");
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractClientStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractClientStoreContract.java
@@ -1,0 +1,71 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contract tests for any {@link ClientStore} implementation. Subclasses
+ * provide a {@link #createStore(Set)} factory that returns a store
+ * seeded with the given clients.
+ */
+public abstract class AbstractClientStoreContract {
+
+    protected abstract ClientStore createStore(Set<Client> clients);
+
+    private Client sample(String id) {
+        return new Client(
+                id,
+                Set.of(new ClientSecret("hashed:abc", null, null)),
+                Set.of("https://app/cb"),
+                Set.of(),
+                Set.of("openid"),
+                Set.of(GrantType.AUTHORIZATION_CODE),
+                Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC),
+                true,
+                false,
+                Duration.ofMinutes(15),
+                Duration.ofDays(30),
+                RefreshTokenUsage.ONE_TIME,
+                Map.of(),
+                true);
+    }
+
+    @Test
+    void findByIdReturnsSeededClient() {
+        Client c = sample("c1");
+        ClientStore store = createStore(Set.of(c));
+        assertThat(store.findById("c1")).isEqualTo(c);
+    }
+
+    @Test
+    void findByIdReturnsNullForUnknown() {
+        ClientStore store = createStore(Set.of(sample("c1")));
+        assertThat(store.findById("nope")).isNull();
+    }
+
+    @Test
+    void existsTrueForKnown() {
+        ClientStore store = createStore(Set.of(sample("c1")));
+        assertThat(store.exists("c1")).isTrue();
+    }
+
+    @Test
+    void existsFalseForUnknown() {
+        ClientStore store = createStore(Set.of(sample("c1")));
+        assertThat(store.exists("nope")).isFalse();
+    }
+
+    @Test
+    void findByIdReturnsDistinctClients() {
+        Client a = sample("a");
+        Client b = sample("b");
+        ClientStore store = createStore(Set.of(a, b));
+        assertThat(store.findById("a")).isEqualTo(a);
+        assertThat(store.findById("b")).isEqualTo(b);
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractConsentStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractConsentStoreContract.java
@@ -1,0 +1,62 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contract tests for any {@link ConsentStore} implementation. Subclasses
+ * provide a {@link #createStore()} factory that returns an empty store.
+ */
+public abstract class AbstractConsentStoreContract {
+
+    protected abstract ConsentStore createStore();
+
+    private Consent sample(String subject, String client) {
+        return new Consent(subject, client, Set.of("openid"),
+                Instant.parse("2026-08-01T00:00:00Z"));
+    }
+
+    @Test
+    void findReturnsNullForUnknownKey() {
+        ConsentStore store = createStore();
+        assertThat(store.find("sub", "client")).isNull();
+    }
+
+    @Test
+    void storeAndFindRoundTrip() {
+        ConsentStore store = createStore();
+        Consent c = sample("sub-1", "client-1");
+        store.store(c);
+        assertThat(store.find("sub-1", "client-1")).isEqualTo(c);
+    }
+
+    @Test
+    void storeReplacesPriorConsent() {
+        ConsentStore store = createStore();
+        Consent first = new Consent("sub-1", "client-1", Set.of("openid"),
+                Instant.parse("2026-06-01T00:00:00Z"));
+        Consent second = new Consent("sub-1", "client-1", Set.of("openid", "profile"),
+                Instant.parse("2026-09-01T00:00:00Z"));
+        store.store(first);
+        store.store(second);
+        assertThat(store.find("sub-1", "client-1")).isEqualTo(second);
+    }
+
+    @Test
+    void removeMakesConsentUnreachable() {
+        ConsentStore store = createStore();
+        store.store(sample("sub-1", "client-1"));
+        store.remove("sub-1", "client-1");
+        assertThat(store.find("sub-1", "client-1")).isNull();
+    }
+
+    @Test
+    void removeIsNoOpForUnknownKey() {
+        ConsentStore store = createStore();
+        store.remove("nope", "nope"); // must not throw
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractResourceStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractResourceStoreContract.java
@@ -1,0 +1,64 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contract tests for any {@link ResourceStore} implementation. Subclasses
+ * provide a {@link #createStore(Set, Set)} factory that returns a store
+ * seeded with the given identity scopes and protected resources.
+ */
+public abstract class AbstractResourceStoreContract {
+
+    protected abstract ResourceStore createStore(Set<IdentityScope> identityScopes,
+                                                 Set<ProtectedResource> protectedResources);
+
+    private IdentityScope openid() {
+        return new IdentityScope("openid", "OpenID Connect", Set.of("sub"));
+    }
+
+    private IdentityScope profile() {
+        return new IdentityScope("profile", "Profile", Set.of("name", "given_name", "family_name"));
+    }
+
+    private ProtectedResource api1() {
+        return new ProtectedResource("api1", "API One",
+                Set.of(new ResourceScope("api1.read", "Read"),
+                       new ResourceScope("api1.write", "Write")));
+    }
+
+    @Test
+    void findIdentityScopeReturnsSeededScope() {
+        ResourceStore store = createStore(Set.of(openid(), profile()), Set.of());
+        assertThat(store.findIdentityScope("openid")).isEqualTo(openid());
+    }
+
+    @Test
+    void findIdentityScopeReturnsNullForUnknown() {
+        ResourceStore store = createStore(Set.of(openid()), Set.of());
+        assertThat(store.findIdentityScope("nope")).isNull();
+    }
+
+    @Test
+    void findProtectedResourceReturnsSeeded() {
+        ResourceStore store = createStore(Set.of(), Set.of(api1()));
+        assertThat(store.findProtectedResource("api1")).isEqualTo(api1());
+    }
+
+    @Test
+    void findIdentityScopesByNameFiltersUnknown() {
+        ResourceStore store = createStore(Set.of(openid(), profile()), Set.of());
+        assertThat(store.findIdentityScopesByName(Set.of("openid", "nope")))
+                .containsExactly(openid());
+    }
+
+    @Test
+    void findResourcesByScopeReturnsResourcesWhoseScopesIntersect() {
+        ResourceStore store = createStore(Set.of(), Set.of(api1()));
+        assertThat(store.findResourcesByScope(Set.of("api1.read", "api1.delete")))
+                .containsExactly(api1());
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractTokenStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractTokenStoreContract.java
@@ -1,0 +1,101 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contract tests for any {@link TokenStore} implementation. Subclasses provide
+ * a {@link #createStore(Clock)} factory; the {@code clock} is used to compute
+ * "is this grant expired?" — implementations that implement expiration via
+ * system clock should accept this clock as a fixture.
+ */
+public abstract class AbstractTokenStoreContract {
+
+    /**
+     * Subclass-provided factory.
+     *
+     * @param clock the clock to use for expiration checks
+     * @return an empty TokenStore
+     */
+    protected abstract TokenStore createStore(Clock clock);
+
+    private static final Instant NOW = Instant.parse("2026-05-01T00:00:00Z");
+    private static final Clock FIXED = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private PersistedGrant grant(String handle, String subject, String client,
+                                 GrantType type, Instant expiration) {
+        return new PersistedGrant(handle, type, subject, client,
+                Set.of("openid"), NOW, expiration, null, "{}");
+    }
+
+    @Test
+    void storeAndFindByHandleRoundTrip() {
+        TokenStore store = createStore(FIXED);
+        PersistedGrant g = grant("h1", "sub-1", "client-1",
+                GrantType.AUTHORIZATION_CODE, NOW.plusSeconds(300));
+        store.store(g);
+        assertThat(store.findByHandle("h1")).isEqualTo(g);
+    }
+
+    @Test
+    void findByHandleReturnsNullForUnknown() {
+        TokenStore store = createStore(FIXED);
+        assertThat(store.findByHandle("nope")).isNull();
+    }
+
+    @Test
+    void findByHandleReturnsNullForExpiredGrant() {
+        TokenStore store = createStore(FIXED);
+        store.store(grant("h-expired", "sub-1", "client-1",
+                GrantType.REFRESH_TOKEN, NOW.minusSeconds(1)));
+        assertThat(store.findByHandle("h-expired")).isNull();
+    }
+
+    @Test
+    void removeMakesGrantUnreachable() {
+        TokenStore store = createStore(FIXED);
+        store.store(grant("h1", "sub-1", "client-1",
+                GrantType.AUTHORIZATION_CODE, NOW.plusSeconds(300)));
+        store.remove("h1");
+        assertThat(store.findByHandle("h1")).isNull();
+    }
+
+    @Test
+    void removeIsNoOpForUnknownHandle() {
+        TokenStore store = createStore(FIXED);
+        store.remove("nope"); // must not throw
+    }
+
+    @Test
+    void removeAllForSubjectClientRemovesEverything() {
+        TokenStore store = createStore(FIXED);
+        store.store(grant("h1", "sub-1", "client-1",
+                GrantType.AUTHORIZATION_CODE, NOW.plusSeconds(300)));
+        store.store(grant("h2", "sub-1", "client-1",
+                GrantType.REFRESH_TOKEN, NOW.plusSeconds(300)));
+        store.store(grant("h3", "sub-2", "client-1",
+                GrantType.REFRESH_TOKEN, NOW.plusSeconds(300)));
+        store.removeAll("sub-1", "client-1");
+        assertThat(store.findByHandle("h1")).isNull();
+        assertThat(store.findByHandle("h2")).isNull();
+        assertThat(store.findByHandle("h3")).isNotNull();
+    }
+
+    @Test
+    void removeAllForSubjectClientTypeFiltersByType() {
+        TokenStore store = createStore(FIXED);
+        store.store(grant("h-code", "sub-1", "client-1",
+                GrantType.AUTHORIZATION_CODE, NOW.plusSeconds(300)));
+        store.store(grant("h-refresh", "sub-1", "client-1",
+                GrantType.REFRESH_TOKEN, NOW.plusSeconds(300)));
+        store.removeAll("sub-1", "client-1", GrantType.AUTHORIZATION_CODE);
+        assertThat(store.findByHandle("h-code")).isNull();
+        assertThat(store.findByHandle("h-refresh")).isNotNull();
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractUserStoreContract.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/AbstractUserStoreContract.java
@@ -1,0 +1,128 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Contract tests for any {@link UserStore} implementation. Subclasses provide
+ * a {@link #createStore(Set, Map, Map, Map)} factory that returns a store
+ * pre-seeded with users, password mappings, federated mappings, and per-subject
+ * claim sets.
+ */
+public abstract class AbstractUserStoreContract {
+
+    /**
+     * Subclass-provided factory.
+     *
+     * @param users               users to seed
+     * @param passwords           map of {@code username -> credential}; auth succeeds
+     *                            iff the submitted credential matches
+     * @param federatedMappings   map of {@code "providerId|externalSubject" -> User}
+     * @param claimsBySubject     map of {@code subjectId -> claims}
+     */
+    protected abstract UserStore createStore(Set<User> users,
+                                             Map<String, String> passwords,
+                                             Map<String, User> federatedMappings,
+                                             Map<String, Set<UserClaim>> claimsBySubject);
+
+    private User alice() {
+        return new User("sub-alice", "alice", true, Map.of());
+    }
+
+    private User bob() {
+        return new User("sub-bob", "bob", true, Map.of());
+    }
+
+    @Test
+    void findByIdReturnsSeededUser() {
+        UserStore store = createStore(Set.of(alice()), Map.of(), Map.of(), Map.of());
+        assertThat(store.findById("sub-alice")).isEqualTo(alice());
+    }
+
+    @Test
+    void findByIdReturnsNullForUnknown() {
+        UserStore store = createStore(Set.of(alice()), Map.of(), Map.of(), Map.of());
+        assertThat(store.findById("nope")).isNull();
+    }
+
+    @Test
+    void findByUsernameReturnsSeededUser() {
+        UserStore store = createStore(Set.of(alice()), Map.of(), Map.of(), Map.of());
+        assertThat(store.findByUsername("alice")).isEqualTo(alice());
+    }
+
+    @Test
+    void authenticateSucceedsWithCorrectCredential() {
+        UserStore store = createStore(
+                Set.of(alice()),
+                Map.of("alice", "password123"),
+                Map.of(), Map.of());
+        AuthenticationResult result = store.authenticate("alice", "password123");
+        assertThat(result).isInstanceOf(AuthenticationResult.Success.class);
+        assertThat(((AuthenticationResult.Success) result).user()).isEqualTo(alice());
+    }
+
+    @Test
+    void authenticateReturnsInvalidCredentialsForWrongPassword() {
+        UserStore store = createStore(
+                Set.of(alice()),
+                Map.of("alice", "password123"),
+                Map.of(), Map.of());
+        AuthenticationResult result = store.authenticate("alice", "wrong");
+        assertThat(result).isInstanceOf(AuthenticationResult.InvalidCredentials.class);
+    }
+
+    @Test
+    void authenticateReturnsInvalidCredentialsForUnknownUsername() {
+        UserStore store = createStore(
+                Set.of(alice()),
+                Map.of("alice", "password123"),
+                Map.of(), Map.of());
+        AuthenticationResult result = store.authenticate("nope", "password123");
+        assertThat(result).isInstanceOf(AuthenticationResult.InvalidCredentials.class);
+    }
+
+    @Test
+    void findByExternalProviderReturnsLinkedUser() {
+        UserStore store = createStore(
+                Set.of(alice()),
+                Map.of(),
+                Map.of("google|alice@google", alice()),
+                Map.of());
+        assertThat(store.findByExternalProvider("google", "alice@google")).isEqualTo(alice());
+    }
+
+    @Test
+    void findByExternalProviderReturnsNullForUnknown() {
+        UserStore store = createStore(Set.of(), Map.of(), Map.of(), Map.of());
+        assertThat(store.findByExternalProvider("google", "nope")).isNull();
+    }
+
+    @Test
+    void createFromExternalProviderIsIdempotent() {
+        UserStore store = createStore(Set.of(alice()), Map.of(),
+                Map.of("google|ext-1", alice()), Map.of());
+        BrokeredAuthentication b = new BrokeredAuthentication("google", "ext-1", Map.of());
+        User first = store.createFromExternalProvider(b);
+        User second = store.createFromExternalProvider(b);
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void claimsReturnsSeededClaims() {
+        UserClaim email = new UserClaim("email", "alice@example.com");
+        UserStore store = createStore(Set.of(alice()), Map.of(), Map.of(),
+                Map.of("sub-alice", Set.of(email)));
+        assertThat(store.claims("sub-alice")).containsExactly(email);
+    }
+
+    @Test
+    void claimsReturnsEmptyForUnknownSubject() {
+        UserStore store = createStore(Set.of(alice()), Map.of(), Map.of(), Map.of());
+        assertThat(store.claims("nope")).isEmpty();
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ClientStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ClientStoreTypesTest.java
@@ -1,0 +1,78 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ClientStoreTypesTest {
+
+    @Test
+    void clientSecretRejectsNullValue() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new ClientSecret(null, "desc", null));
+    }
+
+    @Test
+    void clientSecretAcceptsNullExpiration() {
+        ClientSecret s = new ClientSecret("hashed:abc", "primary", null);
+        assertThat(s.value()).isEqualTo("hashed:abc");
+        assertThat(s.expiration()).isNull();
+    }
+
+    @Test
+    void clientRejectsNullClientId() {
+        assertThatNullPointerException().isThrownBy(() -> sampleClient(null));
+    }
+
+    @Test
+    void clientRejectsBlankClientId() {
+        assertThatIllegalArgumentException().isThrownBy(() -> sampleClient(""));
+    }
+
+    @Test
+    void clientReturnsImmutableCollections() {
+        Client c = sampleClient("c1");
+        assertThat(c.redirectUris()).containsExactly("https://app/cb");
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> c.redirectUris().add("https://other/cb"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private Client sampleClient(String id) {
+        return new Client(
+                id,
+                Set.of(new ClientSecret("hashed:abc", "primary", null)),
+                Set.of("https://app/cb"),
+                Set.of("https://app/post-logout"),
+                Set.of("openid", "profile"),
+                Set.of(GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN),
+                Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC),
+                true,
+                true,
+                Duration.ofMinutes(15),
+                Duration.ofDays(30),
+                RefreshTokenUsage.ONE_TIME,
+                Map.of(),
+                true);
+    }
+
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractClientStoreContract {
+        @Override
+        protected ClientStore createStore(java.util.Set<Client> clients) {
+            java.util.Map<String, Client> byId = new java.util.HashMap<>();
+            for (Client c : clients) byId.put(c.clientId(), c);
+            java.util.Map<String, Client> snapshot = java.util.Map.copyOf(byId);
+            return new ClientStore() {
+                @Override public Client findById(String id) { return snapshot.get(id); }
+                @Override public boolean exists(String id) { return snapshot.containsKey(id); }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ConsentStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ConsentStoreTypesTest.java
@@ -1,0 +1,61 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ConsentStoreTypesTest {
+
+    @Test
+    void consentRejectsBlankSubjectId() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new Consent("", "client", Set.of("openid"), Instant.now()));
+    }
+
+    @Test
+    void consentRejectsBlankClientId() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new Consent("sub", "", Set.of("openid"), Instant.now()));
+    }
+
+    @Test
+    void consentRejectsNullExpiration() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new Consent("sub", "client", Set.of("openid"), null));
+    }
+
+    @Test
+    void consentCopiesScopesToImmutable() {
+        Consent c = new Consent("sub", "client", Set.of("openid"), Instant.now().plusSeconds(60));
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> c.scopes().add("api"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractConsentStoreContract {
+        @Override
+        protected ConsentStore createStore() {
+            java.util.Map<String, Consent> backing = new java.util.HashMap<>();
+            return new ConsentStore() {
+                private String key(String s, String c) { return s + "|" + c; }
+                @Override
+                public Consent find(String s, String c) {
+                    return backing.get(key(s, c));
+                }
+                @Override
+                public void store(Consent consent) {
+                    backing.put(key(consent.subjectId(), consent.clientId()), consent);
+                }
+                @Override
+                public void remove(String s, String c) {
+                    backing.remove(key(s, c));
+                }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/EnumsTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/EnumsTest.java
@@ -1,0 +1,48 @@
+package io.tokido.core.identity.spi;
+
+import io.tokido.core.identity.key.KeyState;
+import io.tokido.core.identity.key.SignatureAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnumsTest {
+
+    @Test
+    void grantTypeEnumeratesSupportedGrants() {
+        assertThat(GrantType.values()).contains(
+                GrantType.AUTHORIZATION_CODE,
+                GrantType.REFRESH_TOKEN,
+                GrantType.CLIENT_CREDENTIALS);
+    }
+
+    @Test
+    void clientAuthenticationMethodEnumeratesRfc6749Methods() {
+        assertThat(ClientAuthenticationMethod.values()).contains(
+                ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                ClientAuthenticationMethod.NONE);
+    }
+
+    @Test
+    void refreshTokenUsageHasOneTimeAndReuse() {
+        assertThat(RefreshTokenUsage.values()).contains(
+                RefreshTokenUsage.ONE_TIME,
+                RefreshTokenUsage.REUSE);
+    }
+
+    @Test
+    void signatureAlgorithmCoversCommonJwsAlgs() {
+        assertThat(SignatureAlgorithm.values()).contains(
+                SignatureAlgorithm.RS256,
+                SignatureAlgorithm.ES256,
+                SignatureAlgorithm.EDDSA);
+    }
+
+    @Test
+    void keyStateHasAtLeastActiveAndRetired() {
+        assertThat(KeyState.values()).contains(
+                KeyState.ACTIVE,
+                KeyState.RETIRED);
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ResourceStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/ResourceStoreTypesTest.java
@@ -1,0 +1,93 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ResourceStoreTypesTest {
+
+    @Test
+    void identityScopeMustHaveNonBlankName() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new IdentityScope("", "Display", Set.of()));
+    }
+
+    @Test
+    void identityScopeExposesUserClaimNames() {
+        IdentityScope s = new IdentityScope("profile", "User profile", Set.of("name", "given_name"));
+        assertThat(s.userClaimNames()).containsExactlyInAnyOrder("name", "given_name");
+    }
+
+    @Test
+    void resourceScopeAcceptsNullDisplayName() {
+        ResourceScope s = new ResourceScope("api.read", null);
+        assertThat(s.displayName()).isNull();
+    }
+
+    @Test
+    void protectedResourceRequiresNonNullScopes() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new ProtectedResource("api1", "API One", null));
+    }
+
+    @Test
+    void protectedResourceCopiesScopesToImmutable() {
+        ProtectedResource r = new ProtectedResource("api1", "API One",
+                Set.of(new ResourceScope("api.read", "Read"),
+                       new ResourceScope("api.write", "Write")));
+        assertThat(r.scopes()).hasSize(2);
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> r.scopes().add(new ResourceScope("api.delete", "Delete")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractResourceStoreContract {
+        @Override
+        protected ResourceStore createStore(java.util.Set<IdentityScope> ids,
+                                            java.util.Set<ProtectedResource> rs) {
+            java.util.Map<String, IdentityScope> idMap = new java.util.HashMap<>();
+            for (IdentityScope s : ids) idMap.put(s.name(), s);
+            java.util.Map<String, ProtectedResource> rMap = new java.util.HashMap<>();
+            for (ProtectedResource r : rs) rMap.put(r.name(), r);
+            java.util.Map<String, IdentityScope> idSnap = java.util.Map.copyOf(idMap);
+            java.util.Map<String, ProtectedResource> rSnap = java.util.Map.copyOf(rMap);
+            return new ResourceStore() {
+                @Override
+                public IdentityScope findIdentityScope(String name) {
+                    return idSnap.get(name);
+                }
+                @Override
+                public ProtectedResource findProtectedResource(String name) {
+                    return rSnap.get(name);
+                }
+                @Override
+                public java.util.Set<IdentityScope> findIdentityScopesByName(java.util.Set<String> names) {
+                    java.util.Set<IdentityScope> out = new java.util.HashSet<>();
+                    for (String n : names) {
+                        IdentityScope s = idSnap.get(n);
+                        if (s != null) out.add(s);
+                    }
+                    return java.util.Set.copyOf(out);
+                }
+                @Override
+                public java.util.Set<ProtectedResource> findResourcesByScope(java.util.Set<String> scopeNames) {
+                    java.util.Set<ProtectedResource> out = new java.util.HashSet<>();
+                    for (ProtectedResource r : rSnap.values()) {
+                        for (ResourceScope s : r.scopes()) {
+                            if (scopeNames.contains(s.name())) {
+                                out.add(r);
+                                break;
+                            }
+                        }
+                    }
+                    return java.util.Set.copyOf(out);
+                }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/TokenStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/TokenStoreTypesTest.java
@@ -1,0 +1,90 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class TokenStoreTypesTest {
+
+    @Test
+    void persistedGrantRejectsBlankHandle() {
+        assertThatIllegalArgumentException().isThrownBy(() -> sample(""));
+    }
+
+    @Test
+    void persistedGrantRejectsNullType() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new PersistedGrant("h", null, "sub", "client",
+                        Set.of("openid"), Instant.now(), Instant.now().plusSeconds(60),
+                        null, "{}"));
+    }
+
+    @Test
+    void persistedGrantAcceptsNullConsumedTime() {
+        PersistedGrant g = sample("h-1");
+        assertThat(g.consumedTime()).isNull();
+    }
+
+    @Test
+    void persistedGrantCopiesScopesToImmutable() {
+        PersistedGrant g = sample("h-1");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> g.scopes().add("api"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private PersistedGrant sample(String handle) {
+        return new PersistedGrant(
+                handle,
+                GrantType.AUTHORIZATION_CODE,
+                "sub-1",
+                "client-1",
+                Set.of("openid", "profile"),
+                Instant.parse("2026-05-01T00:00:00Z"),
+                Instant.parse("2026-05-01T00:10:00Z"),
+                null,
+                "{\"opaque\":\"data\"}");
+    }
+
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractTokenStoreContract {
+        @Override
+        protected TokenStore createStore(java.time.Clock clock) {
+            java.util.Map<String, PersistedGrant> backing = new java.util.HashMap<>();
+            return new TokenStore() {
+                @Override
+                public void store(PersistedGrant g) {
+                    backing.put(g.handle(), g);
+                }
+                @Override
+                public PersistedGrant findByHandle(String h) {
+                    PersistedGrant g = backing.get(h);
+                    if (g == null) return null;
+                    if (!g.expiration().isAfter(clock.instant())) return null; // expired
+                    return g;
+                }
+                @Override
+                public void remove(String h) {
+                    backing.remove(h);
+                }
+                @Override
+                public void removeAll(String subjectId, String clientId) {
+                    backing.entrySet().removeIf(e ->
+                            e.getValue().subjectId().equals(subjectId)
+                                    && e.getValue().clientId().equals(clientId));
+                }
+                @Override
+                public void removeAll(String subjectId, String clientId, GrantType type) {
+                    backing.entrySet().removeIf(e ->
+                            e.getValue().subjectId().equals(subjectId)
+                                    && e.getValue().clientId().equals(clientId)
+                                    && e.getValue().type() == type);
+                }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/UserStoreTypesTest.java
+++ b/tokido-core-identity-api/src/test/java/io/tokido/core/identity/spi/UserStoreTypesTest.java
@@ -1,0 +1,115 @@
+package io.tokido.core.identity.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class UserStoreTypesTest {
+
+    @Test
+    void userClaimRejectsBlankType() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new UserClaim("", "v"));
+    }
+
+    @Test
+    void userClaimRejectsNullValue() {
+        assertThatNullPointerException().isThrownBy(() -> new UserClaim("name", null));
+    }
+
+    @Test
+    void userRejectsBlankSubjectId() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new User("", "alice", true, Map.of()));
+    }
+
+    @Test
+    void userCopiesProfileToImmutable() {
+        User u = new User("sub-1", "alice", true, Map.of("email", "alice@example.com"));
+        assertThat(u.profile()).containsEntry("email", "alice@example.com");
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> u.profile().put("k", "v"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void brokeredAuthenticationRejectsBlankProviderId() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new BrokeredAuthentication("", "ext-1", Map.of()));
+    }
+
+    @Test
+    void brokeredAuthenticationRejectsBlankExternalSubject() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new BrokeredAuthentication("google", "", Map.of()));
+    }
+
+    @Test
+    void authenticationResultSuccessRequiresUser() {
+        assertThatNullPointerException().isThrownBy(
+                () -> new AuthenticationResult.Success(null));
+    }
+
+    @Test
+    void authenticationResultFailureVariantsAreNoArg() {
+        AuthenticationResult.InvalidCredentials a = new AuthenticationResult.InvalidCredentials();
+        AuthenticationResult.AccountLocked b = new AuthenticationResult.AccountLocked();
+        AuthenticationResult.AccountDisabled c = new AuthenticationResult.AccountDisabled();
+        assertThat(a).isNotNull();
+        assertThat(b).isNotNull();
+        assertThat(c).isNotNull();
+    }
+
+    @org.junit.jupiter.api.Nested
+    class SmokeContract extends AbstractUserStoreContract {
+        @Override
+        protected UserStore createStore(java.util.Set<User> users,
+                                        java.util.Map<String, String> passwords,
+                                        java.util.Map<String, User> federatedMappings,
+                                        java.util.Map<String, java.util.Set<UserClaim>> claimsBySubject) {
+            java.util.Map<String, User> bySub = new java.util.HashMap<>();
+            java.util.Map<String, User> byName = new java.util.HashMap<>();
+            for (User u : users) {
+                bySub.put(u.subjectId(), u);
+                byName.put(u.username(), u);
+            }
+            java.util.Map<String, User> bySubSnap = java.util.Map.copyOf(bySub);
+            java.util.Map<String, User> byNameSnap = java.util.Map.copyOf(byName);
+            java.util.Map<String, String> pwSnap = java.util.Map.copyOf(passwords);
+            java.util.Map<String, User> fedSnap = java.util.Map.copyOf(federatedMappings);
+            java.util.Map<String, java.util.Set<UserClaim>> claimsSnap =
+                    java.util.Map.copyOf(claimsBySubject);
+            return new UserStore() {
+                @Override public User findById(String s) { return bySubSnap.get(s); }
+                @Override public User findByUsername(String u) { return byNameSnap.get(u); }
+                @Override
+                public AuthenticationResult authenticate(String username, String credential) {
+                    String expected = pwSnap.get(username);
+                    if (expected == null || !expected.equals(credential)) {
+                        return new AuthenticationResult.InvalidCredentials();
+                    }
+                    return new AuthenticationResult.Success(byNameSnap.get(username));
+                }
+                @Override
+                public User findByExternalProvider(String p, String s) {
+                    return fedSnap.get(p + "|" + s);
+                }
+                @Override
+                public User createFromExternalProvider(BrokeredAuthentication b) {
+                    User existing = fedSnap.get(b.providerId() + "|" + b.externalSubject());
+                    if (existing != null) return existing;
+                    throw new UnsupportedOperationException(
+                            "smoke contract does not support creation; seed federatedMappings");
+                }
+                @Override
+                public java.util.Set<UserClaim> claims(String s) {
+                    return claimsSnap.getOrDefault(s, java.util.Set.of());
+                }
+            };
+        }
+    }
+}

--- a/tokido-core-identity-broker/pom.xml
+++ b/tokido-core-identity-broker/pom.xml
@@ -30,6 +30,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tokido-core-identity-broker/src/test/java/io/tokido/core/identity/broker/NoFrameworkImportsTest.java
+++ b/tokido-core-identity-broker/src/test/java/io/tokido/core/identity/broker/NoFrameworkImportsTest.java
@@ -1,0 +1,32 @@
+package io.tokido.core.identity.broker;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture gate: no class in this module may import Spring, Quarkus,
+ * Jakarta, Servlet, or JAX-RS types. Identity modules are framework-agnostic
+ * by ADR-0003.
+ */
+class NoFrameworkImportsTest {
+
+    @Test
+    void noFrameworkImports() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "io.quarkus..",
+                        "jakarta..",
+                        "javax.servlet..",
+                        "jakarta.ws.rs..")
+                .because("identity modules must remain framework-agnostic (ADR-0003)");
+
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.tokido.core.identity.broker"));
+    }
+}

--- a/tokido-core-identity-engine/pom.xml
+++ b/tokido-core-identity-engine/pom.xml
@@ -26,6 +26,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tokido-core-identity-engine/pom.xml
+++ b/tokido-core-identity-engine/pom.xml
@@ -38,20 +38,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/EventSink.java
+++ b/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/EventSink.java
@@ -1,0 +1,36 @@
+package io.tokido.core.identity.engine;
+
+import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Optional audit hook. The engine emits a structured event per significant
+ * lifecycle action (token issued, token revoked, consent granted, broker
+ * callback, etc.). Implementations may forward to logs, metrics, audit
+ * pipelines, or a no-op.
+ *
+ * <p>The default implementation in {@link #noop()} discards every event.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface EventSink {
+
+    /**
+     * Emit one event. Implementations must not block the engine for long.
+     *
+     * @param type       event type (e.g., {@code "token.issued"})
+     * @param timestamp  when the event occurred
+     * @param attributes additional event attributes
+     */
+    void emit(String type, Instant timestamp, Map<String, Object> attributes);
+
+    /**
+     * No-op sink used by default when no sink is supplied.
+     *
+     * @return a sink that drops every event
+     */
+    static EventSink noop() {
+        return (type, timestamp, attributes) -> { /* drop */ };
+    }
+}

--- a/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/IdentityEngine.java
+++ b/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/IdentityEngine.java
@@ -1,0 +1,242 @@
+package io.tokido.core.identity.engine;
+
+import io.tokido.core.identity.key.KeyStore;
+import io.tokido.core.identity.protocol.AuthenticationState;
+import io.tokido.core.identity.protocol.AuthorizeRequest;
+import io.tokido.core.identity.protocol.AuthorizeResult;
+import io.tokido.core.identity.protocol.DiscoveryDocument;
+import io.tokido.core.identity.protocol.EndSessionRequest;
+import io.tokido.core.identity.protocol.EndSessionResult;
+import io.tokido.core.identity.protocol.IntrospectionRequest;
+import io.tokido.core.identity.protocol.IntrospectionResult;
+import io.tokido.core.identity.protocol.JsonWebKeySet;
+import io.tokido.core.identity.protocol.RevocationRequest;
+import io.tokido.core.identity.protocol.RevocationResult;
+import io.tokido.core.identity.protocol.TokenRequest;
+import io.tokido.core.identity.protocol.TokenResult;
+import io.tokido.core.identity.protocol.UserInfoRequest;
+import io.tokido.core.identity.protocol.UserInfoResult;
+import io.tokido.core.identity.spi.ClientStore;
+import io.tokido.core.identity.spi.ConsentStore;
+import io.tokido.core.identity.spi.ResourceStore;
+import io.tokido.core.identity.spi.TokenStore;
+import io.tokido.core.identity.spi.UserStore;
+import org.apiguardian.api.API;
+
+import java.net.URI;
+import java.time.Clock;
+import java.util.Objects;
+
+/**
+ * The pure-function OIDC protocol engine.
+ *
+ * <p>Build with {@link #builder()}, supplying a SPI implementation for each
+ * storage concern, plus a {@link TokenSigner} (typically
+ * {@code NimbusTokenSigner} from {@code tokido-core-identity-jwt}, M2+).
+ *
+ * <p>At M1 every method throws {@link UnsupportedOperationException}; M2
+ * lands the real implementations.
+ *
+ * <p>Thread-safety: the engine itself is stateless; safety follows the SPI
+ * implementations supplied to the builder.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public final class IdentityEngine {
+
+    private final URI issuer;
+    private final ClientStore clientStore;
+    private final ResourceStore resourceStore;
+    private final TokenStore tokenStore;
+    private final UserStore userStore;
+    private final ConsentStore consentStore;
+    private final KeyStore keyStore;
+    private final TokenSigner tokenSigner;
+    private final Clock clock;
+    private final EventSink eventSink;
+
+    private IdentityEngine(Builder b) {
+        this.issuer = Objects.requireNonNull(b.issuer, "issuer");
+        this.clientStore = Objects.requireNonNull(b.clientStore, "clientStore");
+        this.resourceStore = Objects.requireNonNull(b.resourceStore, "resourceStore");
+        this.tokenStore = Objects.requireNonNull(b.tokenStore, "tokenStore");
+        this.userStore = Objects.requireNonNull(b.userStore, "userStore");
+        this.consentStore = Objects.requireNonNull(b.consentStore, "consentStore");
+        this.keyStore = Objects.requireNonNull(b.keyStore, "keyStore");
+        this.tokenSigner = Objects.requireNonNull(b.tokenSigner, "tokenSigner");
+        this.clock = b.clock != null ? b.clock : Clock.systemUTC();
+        this.eventSink = b.eventSink != null ? b.eventSink : EventSink.noop();
+    }
+
+    /**
+     * Open a new engine builder.
+     *
+     * @return a fresh builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Process an OIDC authorize request.
+     *
+     * @param req   the authorize request
+     * @param state browser-session auth state
+     * @return one of the {@link AuthorizeResult} variants
+     */
+    public AuthorizeResult authorize(AuthorizeRequest req, AuthenticationState state) {
+        throw new UnsupportedOperationException("IdentityEngine.authorize lands at M2");
+    }
+
+    /**
+     * Process an OAuth/OIDC token request.
+     *
+     * @param req the token request
+     * @return one of the {@link TokenResult} variants
+     */
+    public TokenResult token(TokenRequest req) {
+        throw new UnsupportedOperationException("IdentityEngine.token lands at M2");
+    }
+
+    /**
+     * Process a UserInfo request.
+     *
+     * @param req the userinfo request
+     * @return one of the {@link UserInfoResult} variants
+     */
+    public UserInfoResult userInfo(UserInfoRequest req) {
+        throw new UnsupportedOperationException("IdentityEngine.userInfo lands at M2");
+    }
+
+    /**
+     * Build the discovery document.
+     *
+     * @return the OIDC discovery document
+     */
+    public DiscoveryDocument discovery() {
+        throw new UnsupportedOperationException("IdentityEngine.discovery lands at M2");
+    }
+
+    /**
+     * Build the JWKS document.
+     *
+     * @return the JWK set served at the JWKS endpoint
+     */
+    public JsonWebKeySet jwks() {
+        throw new UnsupportedOperationException("IdentityEngine.jwks lands at M2");
+    }
+
+    /**
+     * Process an RFC 7662 introspection request.
+     *
+     * @param req the introspection request
+     * @return one of the {@link IntrospectionResult} variants
+     */
+    public IntrospectionResult introspect(IntrospectionRequest req) {
+        throw new UnsupportedOperationException("IdentityEngine.introspect lands at M2");
+    }
+
+    /**
+     * Process an RFC 7009 revocation request.
+     *
+     * @param req the revocation request
+     * @return one of the {@link RevocationResult} variants
+     */
+    public RevocationResult revoke(RevocationRequest req) {
+        throw new UnsupportedOperationException("IdentityEngine.revoke lands at M2");
+    }
+
+    /**
+     * Process an OIDC end-session request.
+     *
+     * @param req the end-session request
+     * @return one of the {@link EndSessionResult} variants
+     */
+    public EndSessionResult endSession(EndSessionRequest req) {
+        throw new UnsupportedOperationException("IdentityEngine.endSession lands at M2");
+    }
+
+    /** Mutable builder. Each field has a fluent setter. */
+    @API(status = API.Status.STABLE, since = "0.1.0-M1")
+    public static final class Builder {
+        private URI issuer;
+        private ClientStore clientStore;
+        private ResourceStore resourceStore;
+        private TokenStore tokenStore;
+        private UserStore userStore;
+        private ConsentStore consentStore;
+        private KeyStore keyStore;
+        private TokenSigner tokenSigner;
+        private Clock clock;
+        private EventSink eventSink;
+
+        private Builder() {}
+
+        /**
+         * @param v issuer URI; required
+         * @return this builder
+         */
+        public Builder issuer(URI v)                   { this.issuer = v; return this; }
+
+        /**
+         * @param v client store; required
+         * @return this builder
+         */
+        public Builder clientStore(ClientStore v)      { this.clientStore = v; return this; }
+
+        /**
+         * @param v resource store; required
+         * @return this builder
+         */
+        public Builder resourceStore(ResourceStore v)  { this.resourceStore = v; return this; }
+
+        /**
+         * @param v token store; required
+         * @return this builder
+         */
+        public Builder tokenStore(TokenStore v)        { this.tokenStore = v; return this; }
+
+        /**
+         * @param v user store; required
+         * @return this builder
+         */
+        public Builder userStore(UserStore v)          { this.userStore = v; return this; }
+
+        /**
+         * @param v consent store; required
+         * @return this builder
+         */
+        public Builder consentStore(ConsentStore v)    { this.consentStore = v; return this; }
+
+        /**
+         * @param v key store; required
+         * @return this builder
+         */
+        public Builder keyStore(KeyStore v)            { this.keyStore = v; return this; }
+
+        /**
+         * @param v token signer; required
+         * @return this builder
+         */
+        public Builder tokenSigner(TokenSigner v)      { this.tokenSigner = v; return this; }
+
+        /**
+         * @param v clock; optional (defaults to {@link Clock#systemUTC()})
+         * @return this builder
+         */
+        public Builder clock(Clock v)                  { this.clock = v; return this; }
+
+        /**
+         * @param v event sink; optional (defaults to {@link EventSink#noop()})
+         * @return this builder
+         */
+        public Builder eventSink(EventSink v)          { this.eventSink = v; return this; }
+
+        /**
+         * Build the engine.
+         *
+         * @return a newly built IdentityEngine
+         * @throws NullPointerException if any required SPI is missing
+         */
+        public IdentityEngine build() { return new IdentityEngine(this); }
+    }
+}

--- a/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/TokenSigner.java
+++ b/tokido-core-identity-engine/src/main/java/io/tokido/core/identity/engine/TokenSigner.java
@@ -1,0 +1,27 @@
+package io.tokido.core.identity.engine;
+
+import io.tokido.core.identity.key.SigningKey;
+import org.apiguardian.api.API;
+
+/**
+ * SPI for signing JWS-protected payloads. The engine emits payloads as
+ * JSON-serialized strings; the signer wraps them in a compact-serialization
+ * JWS using the provided {@link SigningKey}.
+ *
+ * <p>Implemented by {@code NimbusTokenSigner} in {@code tokido-core-identity-jwt}
+ * (M2). The engine module never directly imports any JWT library — it talks
+ * to this SPI.
+ */
+@API(status = API.Status.STABLE, since = "0.1.0-M1")
+public interface TokenSigner {
+
+    /**
+     * Sign {@code payload} with {@code key} and return the compact JWS.
+     *
+     * @param payload the payload to sign (typically JSON)
+     * @param key     the signing key to use
+     * @return the compact-serialized JWS
+     * @throws IllegalStateException if the key cannot be used (state RETIRED, alg mismatch, etc.)
+     */
+    String sign(String payload, SigningKey key);
+}

--- a/tokido-core-identity-engine/src/test/java/io/tokido/core/identity/engine/IdentityEngineTest.java
+++ b/tokido-core-identity-engine/src/test/java/io/tokido/core/identity/engine/IdentityEngineTest.java
@@ -1,0 +1,187 @@
+package io.tokido.core.identity.engine;
+
+import io.tokido.core.identity.protocol.AuthenticationState;
+import io.tokido.core.identity.protocol.AuthorizeRequest;
+import io.tokido.core.identity.protocol.EndSessionRequest;
+import io.tokido.core.identity.protocol.IntrospectionRequest;
+import io.tokido.core.identity.protocol.RevocationRequest;
+import io.tokido.core.identity.protocol.TokenRequest;
+import io.tokido.core.identity.protocol.UserInfoRequest;
+import io.tokido.core.identity.spi.ClientAuthenticationMethod;
+import io.tokido.core.identity.spi.ClientStore;
+import io.tokido.core.identity.spi.ConsentStore;
+import io.tokido.core.identity.spi.ResourceStore;
+import io.tokido.core.identity.spi.TokenStore;
+import io.tokido.core.identity.spi.UserStore;
+import io.tokido.core.identity.key.KeyStore;
+import io.tokido.core.identity.key.SignatureAlgorithm;
+import io.tokido.core.identity.key.SigningKey;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityEngineTest {
+
+    @Test
+    void builderRejectsMissingIssuer() {
+        assertThatNullPointerException().isThrownBy(() ->
+                IdentityEngine.builder()
+                        .clientStore(stubClientStore())
+                        .resourceStore(stubResourceStore())
+                        .tokenStore(stubTokenStore())
+                        .userStore(stubUserStore())
+                        .consentStore(stubConsentStore())
+                        .keyStore(stubKeyStore())
+                        .tokenSigner(stubSigner())
+                        .build());
+    }
+
+    @Test
+    void builderRejectsMissingClientStore() {
+        assertThatNullPointerException().isThrownBy(() ->
+                IdentityEngine.builder()
+                        .issuer(URI.create("https://issuer.example/"))
+                        .resourceStore(stubResourceStore())
+                        .tokenStore(stubTokenStore())
+                        .userStore(stubUserStore())
+                        .consentStore(stubConsentStore())
+                        .keyStore(stubKeyStore())
+                        .tokenSigner(stubSigner())
+                        .build());
+    }
+
+    @Test
+    void buildSucceedsWithAllRequiredSpis() {
+        IdentityEngine engine = fullyWiredEngine();
+        assertThat(engine).isNotNull();
+    }
+
+    @Test
+    void buildSucceedsWithCustomClockAndEventSink() {
+        IdentityEngine engine = IdentityEngine.builder()
+                .issuer(URI.create("https://issuer.example/"))
+                .clientStore(stubClientStore())
+                .resourceStore(stubResourceStore())
+                .tokenStore(stubTokenStore())
+                .userStore(stubUserStore())
+                .consentStore(stubConsentStore())
+                .keyStore(stubKeyStore())
+                .tokenSigner(stubSigner())
+                .clock(Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC))
+                .eventSink((t, ts, a) -> { /* test sink */ })
+                .build();
+        assertThat(engine).isNotNull();
+    }
+
+    @Test
+    void allMethodsThrowUnsupportedAtM1() {
+        IdentityEngine engine = fullyWiredEngine();
+        AuthorizeRequest auth = new AuthorizeRequest("c", "code", null, Set.of("openid"),
+                null, null, null, null, null, Set.of(), null, null, null, null, Map.of());
+        TokenRequest tok = new TokenRequest("authorization_code", "c", null,
+                ClientAuthenticationMethod.NONE, "code", null, null, null, Set.of(), Map.of());
+        assertThatThrownBy(() -> engine.authorize(auth, AuthenticationState.anonymous()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> engine.token(tok))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> engine.userInfo(new UserInfoRequest("at")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(engine::discovery)
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(engine::jwks)
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> engine.introspect(new IntrospectionRequest("t", null, "c")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> engine.revoke(new RevocationRequest("t", null, "c")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> engine.endSession(new EndSessionRequest(null, null, null)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void noopEventSinkAcceptsEvents() {
+        EventSink sink = EventSink.noop();
+        sink.emit("test", Instant.now(), Map.of("k", "v"));
+        // No exception, no observable behavior. Good.
+    }
+
+    private IdentityEngine fullyWiredEngine() {
+        return IdentityEngine.builder()
+                .issuer(URI.create("https://issuer.example/"))
+                .clientStore(stubClientStore())
+                .resourceStore(stubResourceStore())
+                .tokenStore(stubTokenStore())
+                .userStore(stubUserStore())
+                .consentStore(stubConsentStore())
+                .keyStore(stubKeyStore())
+                .tokenSigner(stubSigner())
+                .build();
+    }
+
+    // ---- minimal SPI stubs (every method throws UoE — engine never invokes them at M1) ----
+
+    private ClientStore stubClientStore() {
+        return new ClientStore() {
+            @Override public io.tokido.core.identity.spi.Client findById(String id) { throw new UnsupportedOperationException(); }
+            @Override public boolean exists(String id) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private ResourceStore stubResourceStore() {
+        return new ResourceStore() {
+            @Override public io.tokido.core.identity.spi.IdentityScope findIdentityScope(String n) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.ProtectedResource findProtectedResource(String n) { throw new UnsupportedOperationException(); }
+            @Override public Set<io.tokido.core.identity.spi.IdentityScope> findIdentityScopesByName(Set<String> ns) { throw new UnsupportedOperationException(); }
+            @Override public Set<io.tokido.core.identity.spi.ProtectedResource> findResourcesByScope(Set<String> ns) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private TokenStore stubTokenStore() {
+        return new TokenStore() {
+            @Override public void store(io.tokido.core.identity.spi.PersistedGrant g) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.PersistedGrant findByHandle(String h) { throw new UnsupportedOperationException(); }
+            @Override public void remove(String h) { throw new UnsupportedOperationException(); }
+            @Override public void removeAll(String s, String c) { throw new UnsupportedOperationException(); }
+            @Override public void removeAll(String s, String c, io.tokido.core.identity.spi.GrantType t) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private UserStore stubUserStore() {
+        return new UserStore() {
+            @Override public io.tokido.core.identity.spi.User findById(String s) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.User findByUsername(String u) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.AuthenticationResult authenticate(String u, String c) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.User findByExternalProvider(String p, String s) { throw new UnsupportedOperationException(); }
+            @Override public io.tokido.core.identity.spi.User createFromExternalProvider(io.tokido.core.identity.spi.BrokeredAuthentication b) { throw new UnsupportedOperationException(); }
+            @Override public Set<io.tokido.core.identity.spi.UserClaim> claims(String s) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private ConsentStore stubConsentStore() {
+        return new ConsentStore() {
+            @Override public io.tokido.core.identity.spi.Consent find(String s, String c) { throw new UnsupportedOperationException(); }
+            @Override public void store(io.tokido.core.identity.spi.Consent c) { throw new UnsupportedOperationException(); }
+            @Override public void remove(String s, String c) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private KeyStore stubKeyStore() {
+        return new KeyStore() {
+            @Override public SigningKey activeSigningKey(SignatureAlgorithm a) { throw new UnsupportedOperationException(); }
+            @Override public Set<SigningKey> allKeys() { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private TokenSigner stubSigner() {
+        return (payload, key) -> { throw new UnsupportedOperationException(); };
+    }
+}

--- a/tokido-core-identity-engine/src/test/java/io/tokido/core/identity/engine/NoFrameworkImportsTest.java
+++ b/tokido-core-identity-engine/src/test/java/io/tokido/core/identity/engine/NoFrameworkImportsTest.java
@@ -1,0 +1,32 @@
+package io.tokido.core.identity.engine;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture gate: no class in this module may import Spring, Quarkus,
+ * Jakarta, Servlet, or JAX-RS types. Identity modules are framework-agnostic
+ * by ADR-0003.
+ */
+class NoFrameworkImportsTest {
+
+    @Test
+    void noFrameworkImports() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "io.quarkus..",
+                        "jakarta..",
+                        "javax.servlet..",
+                        "jakarta.ws.rs..")
+                .because("identity modules must remain framework-agnostic (ADR-0003)");
+
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.tokido.core.identity.engine"));
+    }
+}

--- a/tokido-core-identity-jwt/pom.xml
+++ b/tokido-core-identity-jwt/pom.xml
@@ -26,6 +26,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tokido-core-identity-jwt/src/test/java/io/tokido/core/identity/jwt/NoFrameworkImportsTest.java
+++ b/tokido-core-identity-jwt/src/test/java/io/tokido/core/identity/jwt/NoFrameworkImportsTest.java
@@ -1,0 +1,32 @@
+package io.tokido.core.identity.jwt;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture gate: no class in this module may import Spring, Quarkus,
+ * Jakarta, Servlet, or JAX-RS types. Identity modules are framework-agnostic
+ * by ADR-0003.
+ */
+class NoFrameworkImportsTest {
+
+    @Test
+    void noFrameworkImports() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "io.quarkus..",
+                        "jakarta..",
+                        "javax.servlet..",
+                        "jakarta.ws.rs..")
+                .because("identity modules must remain framework-agnostic (ADR-0003)");
+
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.tokido.core.identity.jwt"));
+    }
+}

--- a/tokido-core-identity-mfa/pom.xml
+++ b/tokido-core-identity-mfa/pom.xml
@@ -34,6 +34,16 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tokido-core-identity-mfa/src/test/java/io/tokido/core/identity/mfa/NoFrameworkImportsTest.java
+++ b/tokido-core-identity-mfa/src/test/java/io/tokido/core/identity/mfa/NoFrameworkImportsTest.java
@@ -1,0 +1,32 @@
+package io.tokido.core.identity.mfa;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architecture gate: no class in this module may import Spring, Quarkus,
+ * Jakarta, Servlet, or JAX-RS types. Identity modules are framework-agnostic
+ * by ADR-0003.
+ */
+class NoFrameworkImportsTest {
+
+    @Test
+    void noFrameworkImports() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "io.quarkus..",
+                        "jakarta..",
+                        "javax.servlet..",
+                        "jakarta.ws.rs..")
+                .because("identity modules must remain framework-agnostic (ADR-0003)");
+
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("io.tokido.core.identity.mfa"));
+    }
+}


### PR DESCRIPTION
## Summary

M1 of the OIDC extension. Locks the public API surface that downstream framework adapters (Project B `tokido-spring`, Project C `tokido-quarkus`) build against. Six core storage SPIs and the full protocol value-type surface are now `@API(STABLE)` and gated by `revapi-maven-plugin`.

- Six core SPIs locked: `ClientStore`, `ResourceStore`, `TokenStore`, `UserStore`, `ConsentStore`, `KeyStore` — each with an abstract contract test class downstream consumers can extend.
- Duende rename pass per ADR-0001: `IdentityResource → IdentityScope`, `ApiResource → ProtectedResource`, `ApiScope → ResourceScope`. `PersistedGrantStore` already renamed to `TokenStore`.
- Six protocol request records: `AuthorizeRequest`, `TokenRequest`, `UserInfoRequest`, `IntrospectionRequest`, `RevocationRequest`, `EndSessionRequest`.
- Six sealed result interfaces: `AuthorizeResult` (5 variants), `TokenResult`, `UserInfoResult`, `IntrospectionResult`, `RevocationResult`, `EndSessionResult`.
- `AuthenticationState`, `DiscoveryDocument`, `JsonWebKey`, `JsonWebKeySet`.
- `IdentityEngine` façade + Builder + `TokenSigner` SPI + `EventSink` SPI in `tokido-core-identity-engine` — every façade method throws `UnsupportedOperationException` until M2.
- ArchUnit no-framework-imports gate in all five identity modules (engine/jwt/broker/mfa join identity-api).
- `revapi-maven-plugin` baseline configured against latest-release; engages once M1 publishes.
- README updated; conformance unchanged at `0/35`.

## Notable choices

- `KeyStore.rotate(KeyRotationPolicy)` from project-A doc §5 is intentionally **out of M1**; lands at M2 with `KeyRotationPolicy` per ADR-0007.
- `AuthenticationStrategy` SPI (project-A doc §4.5) is **out of M1**; the master plan schedules it at M4 alongside the MFA bridge.
- All record canonical constructors defensively copy collection fields to immutable form.
- Each SPI has both a per-record validation test class and an abstract contract base; a nested `SmokeContract` inside the types test exercises the abstract base against a trivial in-memory impl for coverage.

## Test plan

- [x] `mvn verify -DskipITs` green across 12 modules
- [x] 119+ unit tests pass (per-record validation, contract tests via SmokeContract, NoFrameworkImportsTest in 5 modules, IdentityEngineTest)
- [x] Coverage ≥ 90% on `identity-api` and `identity-engine`
- [x] ArchUnit no-framework gate active in all 5 identity modules
- [ ] Wait for `oidc-conformance` workflow to pass (still 0/35; engine impl lands M2)
- [ ] Wait for `mvn verify` workflow to pass

## Release plan (post-merge)

1. Bump versions: parent + existing modules `2.0.0-M1-SNAPSHOT` → `2.0.0-M1`; identity modules `0.1.0-M1-SNAPSHOT` → `0.1.0-M1`.
2. Tag `0.1.0-M1`.
3. Create GitHub Release — fires `release.yml`, publishes to Maven Central.
4. Bump back to `2.0.0-M2-SNAPSHOT` / `0.1.0-M2-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)