### PR TITLE
feat: v0.1 review follow-ups — method-aware routing + optional dev keystore

### DIFF
--- a/adapters/tokido-identity-spring-boot-starter/pom.xml
+++ b/adapters/tokido-identity-spring-boot-starter/pom.xml
@@ -15,7 +15,8 @@
         <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-api</artifactId></dependency>
         <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-engine</artifactId></dependency>
         <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-http</artifactId></dependency>
-        <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-dev</artifactId></dependency>
+        <!-- Optional: dev-only ephemeral KeyStore. Consumers opt in by declaring it themselves. -->
+        <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-dev</artifactId><optional>true</optional></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-autoconfigure</artifactId></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>

--- a/adapters/tokido-identity-spring-boot-starter/src/main/java/io/tokido/identity/spring/DiscoveryController.java
+++ b/adapters/tokido-identity-spring-boot-starter/src/main/java/io/tokido/identity/spring/DiscoveryController.java
@@ -5,6 +5,7 @@ import io.tokido.identity.http.HttpResponse;
 import io.tokido.identity.http.Router;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Binds the framework-neutral Router to Spring MVC. Thin shim, no logic. */
@@ -27,11 +28,13 @@ public class DiscoveryController {
         return toEntity(router.route(new HttpRequest("GET", "/jwks")));
     }
 
-    @GetMapping({"/authorize", "/token", "/userinfo"})
+    @RequestMapping({"/authorize", "/token", "/userinfo"})
     public ResponseEntity<String> placeholder(jakarta.servlet.http.HttpServletRequest req) {
+        // All methods forward to the route table (which answers 501 for unbuilt
+        // endpoints regardless of method), so Spring and non-Spring adapters agree.
         // The route table knows context-relative paths; strip the servlet context path.
         String path = req.getRequestURI().substring(req.getContextPath().length());
-        return toEntity(router.route(new HttpRequest("GET", path)));
+        return toEntity(router.route(new HttpRequest(req.getMethod(), path)));
     }
 
     private ResponseEntity<String> toEntity(HttpResponse r) {

--- a/adapters/tokido-identity-spring-boot-starter/src/main/java/io/tokido/identity/spring/TokidoIdentityAutoConfiguration.java
+++ b/adapters/tokido-identity-spring-boot-starter/src/main/java/io/tokido/identity/spring/TokidoIdentityAutoConfiguration.java
@@ -5,7 +5,9 @@ import io.tokido.identity.dev.InMemoryKeyStore;
 import io.tokido.identity.engine.IdentityEngine;
 import io.tokido.identity.http.Router;
 import io.tokido.identity.key.KeyStore;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -24,26 +26,50 @@ public class TokidoIdentityAutoConfiguration {
         return Clock.systemUTC();
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public KeyStore tokidoKeyStore(TokidoIdentityProperties props, Clock clock) {
-        if (!props.isDevKeys()) {
-            throw new IllegalStateException(
-                    "No KeyStore bean is defined. Provide a production KeyStore bean, or set "
-                    + "tokido.identity.dev-keys=true to use the EPHEMERAL dev key (never in production).");
+    /**
+     * Dev-key fallback. tokido-identity-dev is an OPTIONAL dependency of the
+     * starter, so this configuration only activates when the consumer has put
+     * it on the classpath deliberately; production classpaths never carry the
+     * ephemeral-key code path.
+     *
+     * <p>Deliberately NOT annotated {@code @Configuration}: it is processed as a
+     * lite member of this auto-configuration only. A {@code @Configuration}
+     * meta-{@code @Component} annotation would make it eligible for component
+     * scanning, and an app scanning this package would then register it before
+     * user beans, breaking {@code @ConditionalOnMissingBean} ordering.
+     */
+    @ConditionalOnClass(InMemoryKeyStore.class)
+    static class DevKeyStoreConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        KeyStore tokidoKeyStore(TokidoIdentityProperties props, Clock clock) {
+            if (!props.isDevKeys()) {
+                throw new IllegalStateException(
+                        "No KeyStore bean is defined. Provide a production KeyStore bean, or set "
+                        + "tokido.identity.dev-keys=true to use the EPHEMERAL dev key (never in production).");
+            }
+            return InMemoryKeyStore.ephemeral(clock);
         }
-        return InMemoryKeyStore.ephemeral(clock);
     }
 
     // NOTE: a TokenSigner bean is added here in v0.2 when IdentityEngine mints tokens.
 
     @Bean
     @ConditionalOnMissingBean
-    public IdentityEngine tokidoIdentityEngine(TokidoIdentityProperties props, KeyStore keyStore, Clock clock) {
+    public IdentityEngine tokidoIdentityEngine(TokidoIdentityProperties props,
+                                               ObjectProvider<KeyStore> keyStore, Clock clock) {
         if (props.getIssuer() == null || props.getIssuer().isBlank()) {
             throw new IllegalStateException("tokido.identity.issuer is required");
         }
-        return new IdentityEngine(new DiscoveryConfig(URI.create(props.getIssuer())), keyStore, clock);
+        KeyStore ks = keyStore.getIfAvailable();
+        if (ks == null) {
+            throw new IllegalStateException(
+                    "No KeyStore bean is defined and tokido-identity-dev is not on the classpath. "
+                    + "Provide a production KeyStore bean, or add the optional io.tokido:tokido-identity-dev "
+                    + "dependency and set tokido.identity.dev-keys=true (dev only, never in production).");
+        }
+        return new IdentityEngine(new DiscoveryConfig(URI.create(props.getIssuer())), ks, clock);
     }
 
     @Bean

--- a/adapters/tokido-identity-spring-boot-starter/src/test/java/io/tokido/identity/spring/DiscoveryEndpointsTest.java
+++ b/adapters/tokido-identity-spring-boot-starter/src/test/java/io/tokido/identity/spring/DiscoveryEndpointsTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(properties = {
@@ -41,5 +42,18 @@ class DiscoveryEndpointsTest {
     @Test
     void unbuilt_endpoint_is_501() throws Exception {
         mvc.perform(get("/authorize")).andExpect(status().isNotImplemented());
+    }
+
+    @Test
+    void unbuilt_endpoint_is_501_for_any_method() throws Exception {
+        // POST /token must say "not built yet" (501), not "wrong method" (405),
+        // and behave identically to non-Spring adapters routing via the table.
+        mvc.perform(post("/token")).andExpect(status().isNotImplemented());
+        mvc.perform(post("/authorize")).andExpect(status().isNotImplemented());
+    }
+
+    @Test
+    void wrong_method_on_jwks_is_405() throws Exception {
+        mvc.perform(post("/jwks")).andExpect(status().isMethodNotAllowed());
     }
 }

--- a/adapters/tokido-identity-spring-boot-starter/src/test/java/io/tokido/identity/spring/MissingDevModuleTest.java
+++ b/adapters/tokido-identity-spring-boot-starter/src/test/java/io/tokido/identity/spring/MissingDevModuleTest.java
@@ -1,0 +1,46 @@
+package io.tokido.identity.spring;
+
+import io.tokido.identity.dev.InMemoryKeyStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * tokido-identity-dev is an optional dependency of the starter: production
+ * classpaths without it must fail fast with an actionable message, never a
+ * NoClassDefFoundError.
+ */
+class MissingDevModuleTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TokidoIdentityAutoConfiguration.class))
+            .withPropertyValues("tokido.identity.issuer=https://idp.example.com");
+
+    @Test
+    void fails_with_clear_message_when_dev_module_absent_and_no_keystore_bean() {
+        runner.withClassLoader(new FilteredClassLoader(InMemoryKeyStore.class))
+                .run(ctx -> {
+                    assertThat(ctx).hasFailed();
+                    assertThat(ctx.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("KeyStore");
+                });
+    }
+
+    @Test
+    void dev_keys_property_without_dev_module_names_the_missing_dependency() {
+        runner.withClassLoader(new FilteredClassLoader(InMemoryKeyStore.class))
+                .withPropertyValues("tokido.identity.dev-keys=true")
+                .run(ctx -> {
+                    assertThat(ctx).hasFailed();
+                    assertThat(ctx.getStartupFailure())
+                            .rootCause()
+                            .isInstanceOf(IllegalStateException.class)
+                            .hasMessageContaining("tokido-identity-dev");
+                });
+    }
+}

--- a/examples/idp-spring/pom.xml
+++ b/examples/idp-spring/pom.xml
@@ -20,6 +20,8 @@
     </properties>
     <dependencies>
         <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-spring-boot-starter</artifactId><version>${tokido.version}</version></dependency>
+        <!-- The starter's dev dependency is optional; the example opts in explicitly (pinned PEM dev key). -->
+        <dependency><groupId>io.tokido</groupId><artifactId>tokido-identity-dev</artifactId><version>${tokido.version}</version></dependency>
         <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
     </dependencies>
     <build>

--- a/tokido-identity-http/src/main/java/io/tokido/identity/http/HttpStatus.java
+++ b/tokido-identity-http/src/main/java/io/tokido/identity/http/HttpStatus.java
@@ -2,7 +2,7 @@ package io.tokido.identity.http;
 
 /** The HTTP status codes the protocol layer emits in v0.1. */
 public enum HttpStatus {
-    OK(200), NOT_FOUND(404), NOT_IMPLEMENTED(501);
+    OK(200), NOT_FOUND(404), METHOD_NOT_ALLOWED(405), NOT_IMPLEMENTED(501);
 
     private final int code;
 

--- a/tokido-identity-http/src/main/java/io/tokido/identity/http/Router.java
+++ b/tokido-identity-http/src/main/java/io/tokido/identity/http/Router.java
@@ -2,8 +2,11 @@ package io.tokido.identity.http;
 
 import io.tokido.identity.engine.IdentityEngine;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Transport-neutral route table mapping a path to an engine call. The single
@@ -27,19 +30,31 @@ public final class Router {
     }
 
     public HttpResponse route(HttpRequest req) {
-        if ("GET".equals(req.method())) {
-            String path = req.path();
-            if (DISCOVERY.equals(path)) {
-                return HttpResponse.json(HttpStatus.OK, engine.discoveryJson(), CACHE);
-            }
-            if (JWKS.equals(path)) {
-                return HttpResponse.json(HttpStatus.OK, engine.jwksJson(), CACHE);
-            }
-            if (NOT_YET_IMPLEMENTED.contains(path)) {
-                return HttpResponse.json(HttpStatus.NOT_IMPLEMENTED, NOT_IMPLEMENTED_BODY, "no-store");
-            }
+        String path = req.path();
+        if (DISCOVERY.equals(path)) {
+            return getOnly(req, engine::discoveryJson);
+        }
+        if (JWKS.equals(path)) {
+            return getOnly(req, engine::jwksJson);
+        }
+        if (NOT_YET_IMPLEMENTED.contains(path)) {
+            // Functionality is entirely unimplemented, so 501 for every method:
+            // a POST /token client should learn "not built yet", not "wrong method".
+            return HttpResponse.json(HttpStatus.NOT_IMPLEMENTED, NOT_IMPLEMENTED_BODY, "no-store");
         }
         return HttpResponse.json(HttpStatus.NOT_FOUND,
                 "{\"error\":\"not_found\"}", "no-store");
+    }
+
+    private static HttpResponse getOnly(HttpRequest req, Supplier<String> body) {
+        if ("GET".equals(req.method())) {
+            return HttpResponse.json(HttpStatus.OK, body.get(), CACHE);
+        }
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", MediaType.APPLICATION_JSON);
+        headers.put("Cache-Control", "no-store");
+        headers.put("Allow", "GET");
+        return new HttpResponse(HttpStatus.METHOD_NOT_ALLOWED,
+                "{\"error\":\"method_not_allowed\"}", headers);
     }
 }

--- a/tokido-identity-http/src/test/java/io/tokido/identity/http/RouterTest.java
+++ b/tokido-identity-http/src/test/java/io/tokido/identity/http/RouterTest.java
@@ -73,11 +73,33 @@ class RouterTest {
     }
 
     @Test
-    void non_get_request_returns_404() throws Exception {
+    void wrong_method_on_known_route_returns_405_with_allow() throws Exception {
         Router router = router();
         HttpResponse post = router.route(new HttpRequest("POST", "/jwks"));
-        assertThat(post.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(post.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(post.headers()).containsEntry("Allow", "GET")
+                .containsEntry("Content-Type", "application/json");
         HttpResponse delete = router.route(new HttpRequest("DELETE", "/.well-known/openid-configuration"));
-        assertThat(delete.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(delete.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        assertThat(delete.headers()).containsEntry("Allow", "GET");
+    }
+
+    @Test
+    void any_method_on_unbuilt_endpoint_returns_501() throws Exception {
+        // The endpoint's functionality is entirely unimplemented, so 501 is the
+        // truthful answer for every method (a POST /token client should learn
+        // "not built yet", not "wrong method").
+        Router router = router();
+        for (String method : List.of("GET", "POST", "PUT")) {
+            HttpResponse r = router.route(new HttpRequest(method, "/token"));
+            assertThat(r.status()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        }
+    }
+
+    @Test
+    void unknown_path_returns_404_for_any_method() throws Exception {
+        Router router = router();
+        assertThat(router.route(new HttpRequest("POST", "/nope")).status())
+                .isEqualTo(HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
Two tracked follow-ups from the [PR #45](https://github.com/tokido-io/tokido-identity/pull/45) code review.

## 1. Method-aware route table (`tokido-identity-http`)

- **405 + `Allow: GET`** for wrong-method requests to known GET-only routes (discovery, JWKS) — previously fell through to 404.
- **501 for every method** on unbuilt endpoints (`/authorize`, `/token`, `/userinfo`): a `POST /token` client should learn "not built yet", not "wrong method".
- The Spring shim forwards all methods on placeholder paths through the route table, so Spring and non-Spring adapters answer identically; discovery/JWKS keep `@GetMapping` (Spring's own 405 + automatic HEAD handling apply there).
- Groundwork for the v0.2 POST-only `/token` endpoint.

## 2. Dev keystore is now an optional starter dependency

- `tokido-identity-dev` is `<optional>` in the starter POM — production classpaths no longer carry the ephemeral-key code path. Enabling dev keys now takes two deliberate steps: declare the dependency **and** set `tokido.identity.dev-keys=true`.
- Fallback bean lives in a `@ConditionalOnClass(InMemoryKeyStore)` nested config. Deliberately **not** `@Configuration`-annotated: a nested `@Configuration` is component-scannable (the auto-configuration exclude filter only covers the outer class), and a package-scanning app would register it before user beans, breaking `@ConditionalOnMissingBean`. Caught by `BeanOverrideTest`; documented in the code.
- Missing-everything now fails fast with an actionable message naming the optional dependency, never a `NoClassDefFoundError` (`MissingDevModuleTest` with `FilteredClassLoader`).
- The example app declares `tokido-identity-dev` explicitly (it pins a PEM dev key).

## Quality

TDD throughout (every behavior change red-first). Full reactor `./mvnw clean verify` green — 10 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)